### PR TITLE
Context Refactor & Asset Updates

### DIFF
--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -4,7 +4,7 @@
 # Export the main application context and related modules.
 # Use a try-except block to avoid import errors on build systems.
 try:
-    from .models import *
+    from .domain import *
     from .contexts import *
 except Exception as e:
     import os, sys
@@ -14,4 +14,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.1.4"
+__version__ = "0.2.0"

--- a/tiferet_flask/contexts/flask.py
+++ b/tiferet_flask/contexts/flask.py
@@ -4,21 +4,20 @@
 from typing import Any, Callable
 
 # ** infra
-from flask import Flask, Blueprint, jsonify
+from flask import Flask, Blueprint
 from tiferet.contexts.app import (
-    AppInterfaceContext, 
+    AppInterfaceContext,
     RequestContext,
     TiferetError
 )
-from tiferet.contexts.request import RequestContext
+from tiferet import TiferetAPIError
 from tiferet.contexts.error import ErrorContext
 from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
 
 # ** app
 from .request import FlaskRequestContext
-from ..handlers.flask import FlaskApiHandler
-from ..models import FlaskBlueprint
+from ..domain import FlaskBlueprint
 
 # *** contexts
 
@@ -31,19 +30,27 @@ class FlaskApiContext(AppInterfaceContext):
     # * attribute: flask_app
     flask_app: Flask
 
-    # * attribute: flask_api_handler
-    flask_api_handler: FlaskApiHandler
+    # * attribute: get_blueprints_handler
+    get_blueprints_handler: Callable
+
+    # * attribute: get_route_handler
+    get_route_handler: Callable
+
+    # * attribute: get_status_code_handler
+    get_status_code_handler: Callable
 
     # * init
-    def __init__(self, 
+    def __init__(self,
         interface_id: str,
         features: FeatureContext,
         errors: ErrorContext,
         logging: LoggingContext,
-        flask_api_handler: FlaskApiHandler
+        get_blueprints_handler: Callable,
+        get_route_handler: Callable,
+        get_status_code_handler: Callable
     ):
         '''
-        Initialize the application interface context.
+        Initialize the Flask API context.
 
         :param interface_id: The interface ID.
         :type interface_id: str
@@ -53,15 +60,21 @@ class FlaskApiContext(AppInterfaceContext):
         :type errors: ErrorContext
         :param logging: The logging context.
         :type logging: LoggingContext
-        :param flask_api_handler: The Flask API handler.
-        :type flask_api_handler: FlaskApiHandler
+        :param get_blueprints_handler: Callable to retrieve all Flask blueprints.
+        :type get_blueprints_handler: Callable
+        :param get_route_handler: Callable to retrieve a Flask route by endpoint.
+        :type get_route_handler: Callable
+        :param get_status_code_handler: Callable to retrieve HTTP status code for an error code.
+        :type get_status_code_handler: Callable
         '''
 
         # Call the parent constructor.
         super().__init__(interface_id, features, errors, logging)
 
-        # Set the attributes.
-        self.flask_api_handler = flask_api_handler
+        # Set the handler callables.
+        self.get_blueprints_handler = get_blueprints_handler
+        self.get_route_handler = get_route_handler
+        self.get_status_code_handler = get_status_code_handler
 
     # * method: parse_request
     def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> FlaskRequestContext:
@@ -90,31 +103,29 @@ class FlaskApiContext(AppInterfaceContext):
     # * method: handle_error
     def handle_error(self, error: Exception) -> Any:
         '''
-        Handle the error and return the jsonified response with status code.
+        Handle the error and return the response with status code.
 
         :param error: The error to handle.
         :type error: Exception
-        :return: A tuple of (jsonified_error_response, status_code).
-        :rtype: tuple
+        :return: The error response tuple (response, status_code).
+        :rtype: Any
         '''
 
-        # If the error is not a TiferetError, wrap it in one.
+        # Determine the status code before formatting.
         if not isinstance(error, TiferetError):
-            error = TiferetError(
-                'APP_ERROR',
-                f'An error occurred in the app: {str(error)}',
-                error=str(error)
-            )
             status_code = 500
         else:
-            # Get the status code by the error code on the exception.
-            status_code = self.flask_api_handler.get_status_code(error.error_code)
+            status_code = self.get_status_code_handler(error_code=error.error_code)
 
-        # Get formatted response from ErrorContext.
-        formatted_error = self.errors.handle_error(error)
-
-        # Return the jsonified error response with status code.
-        return jsonify(formatted_error), status_code
+        # Format the error via the parent, catching the TiferetAPIError it raises.
+        try:
+            super().handle_error(error)
+        except TiferetAPIError as api_error:
+            return dict(
+                error_code=api_error.error_code,
+                name=api_error.name,
+                message=api_error.message,
+            ), status_code
 
     # * method: handle_response
     def handle_response(self, request: RequestContext) -> Any:
@@ -123,15 +134,15 @@ class FlaskApiContext(AppInterfaceContext):
 
         :param request: The request context.
         :type request: RequestContext
-        :return: The response.
+        :return: The response tuple (response, status_code).
         :rtype: Any
         '''
 
         # Handle the response from the request context.
         response = super().handle_response(request)
 
-        # Retrieve the route by the request feature id.
-        route = self.flask_api_handler.get_route(request.feature_id)
+        # Retrieve the route by the request feature id via the handler callable.
+        route = self.get_route_handler(endpoint=request.feature_id)
 
         # Return the result as JSON with the specified status code.
         return response, route.status_code
@@ -139,9 +150,9 @@ class FlaskApiContext(AppInterfaceContext):
     # * method: build_blueprint
     def build_blueprint(self, flask_blueprint: FlaskBlueprint, view_func: Callable, **kwargs) -> Blueprint:
         '''
-        Assembles a Flask blueprint from the given FlaskBlueprint model.
+        Assembles a Flask blueprint from the given FlaskBlueprint domain object.
 
-        :param flask_blueprint: The FlaskBlueprint model.
+        :param flask_blueprint: The FlaskBlueprint domain object.
         :type flask_blueprint: FlaskBlueprint
         :param view_func: The view function to handle requests.
         :type view_func: Callable
@@ -153,8 +164,8 @@ class FlaskApiContext(AppInterfaceContext):
 
         # Create the blueprint.
         blueprint = Blueprint(
-            flask_blueprint.name, 
-            __name__, 
+            flask_blueprint.name,
+            __name__,
             url_prefix=flask_blueprint.url_prefix
         )
 
@@ -164,7 +175,7 @@ class FlaskApiContext(AppInterfaceContext):
                 route.rule,
                 route.id,
                 methods=route.methods,
-                view_func=view_func,
+                view_func=lambda: view_func(self, **kwargs),
             )
 
         # Return the created blueprint.
@@ -191,8 +202,8 @@ class FlaskApiContext(AppInterfaceContext):
         flask_app = Flask(__name__)
         CORS(flask_app)
 
-        # Load the Flask blueprints.
-        blueprints = self.flask_api_handler.get_blueprints()
+        # Load the Flask blueprints via the handler callable.
+        blueprints = self.get_blueprints_handler()
 
         # Create and register the blueprints.
         for bp in blueprints:

--- a/tiferet_flask/contexts/request.py
+++ b/tiferet_flask/contexts/request.py
@@ -5,12 +5,15 @@ from typing import Any
 
 # ** infra
 from tiferet.contexts.request import RequestContext
-from tiferet.models import ModelObject
+from tiferet import DomainObject
 
 # *** contexts
 
 # ** context: flask_request_context
 class FlaskRequestContext(RequestContext):
+    '''
+    A request context for Flask API interactions.
+    '''
 
     # * method: handle_response
     def handle_response(self) -> Any:
@@ -27,7 +30,7 @@ class FlaskRequestContext(RequestContext):
         # Handle the response using the parent method.
         return super().handle_response()
 
-    # * method set_result
+    # * method: set_result
     def set_result(self, result: Any):
         '''
         Set the result of the request context.
@@ -40,16 +43,16 @@ class FlaskRequestContext(RequestContext):
         if result is None:
             self.result = ''
 
-        # Convert the response to a dictionary if it's a ModelObject.
-        elif isinstance(result, ModelObject):
+        # Convert the response to a dictionary if it's a DomainObject.
+        elif isinstance(result, DomainObject):
             self.result = result.to_primitive()
 
-        # If the response is a list containing model objects, convert each to a dictionary.
-        elif isinstance(result, list) and all(isinstance(item, ModelObject) for item in result):
+        # If the response is a list containing domain objects, convert each to a dictionary.
+        elif isinstance(result, list) and all(isinstance(item, DomainObject) for item in result):
             self.result = [item.to_primitive() for item in result]
 
-        # If the rsponse is a dict containing model objects, convert each to a dictionary.
-        elif isinstance(result, dict) and all(isinstance(value, ModelObject) for value in result.values()):
+        # If the response is a dict containing domain objects, convert each to a dictionary.
+        elif isinstance(result, dict) and all(isinstance(value, DomainObject) for value in result.values()):
             self.result = {key: value.to_primitive() for key, value in result.items()}
 
         # Otherwise, set the result directly.

--- a/tiferet_flask/contexts/tests/test_flask.py
+++ b/tiferet_flask/contexts/tests/test_flask.py
@@ -4,68 +4,72 @@
 import pytest
 from unittest import mock
 from flask import Flask, Blueprint
-from tiferet import (
-    ModelObject
-)
+from tiferet import DomainObject
+from tiferet.contexts.error import ErrorContext
+from tiferet.contexts.feature import FeatureContext
+from tiferet.contexts.logging import LoggingContext
+from tiferet import TiferetError
 
 # ** app
-from ..flask import *
-from ...models import (
+from ..flask import FlaskApiContext
+from ..request import FlaskRequestContext
+from ...domain import (
     FlaskBlueprint,
     FlaskRoute
+)
+from ...mappers import (
+    FlaskBlueprintAggregate,
+    FlaskRouteAggregate
 )
 
 # *** fixtures
 
-# ** fixture: flask_blueprint
+# ** fixture: sample_route_aggregate
 @pytest.fixture
-def flask_blueprint() -> FlaskBlueprint:
+def sample_route_aggregate() -> FlaskRouteAggregate:
     '''
-    Fixture to provide a sample FlaskBlueprint instance for testing.
-    '''
-
-    return ModelObject.new(
-        FlaskBlueprint,
-        name='sample_blueprint',
-        routes=[
-            ModelObject.new(
-                FlaskRoute,
-                id='sample_route',
-                rule='/sample',
-                methods=['GET', 'POST'],
-                status_code=224
-            )
-        ]
-    )
-
-# ** fixture: flask_api_context
-@pytest.fixture
-def flask_api_context(flask_blueprint: FlaskBlueprint) -> FlaskApiContext:
-    '''
-    Fixture to provide a FlaskApiContext instance for testing.
+    Fixture to provide a sample FlaskRouteAggregate.
     '''
 
-    # Create a mock feature context.
-    mock_features = mock.Mock(spec=FeatureContext)
-
-    # Create a mock error context.
-    mock_errors = mock.Mock(spec=ErrorContext)
-    mock_errors.handle_error.return_value = {'message': 'An error occurred.'}
-
-    # Create a mock logging context.
-    mock_logging = mock.Mock(spec=LoggingContext)
-
-    # Create a mock FlaskApiHandler.
-    mock_handler = mock.Mock(spec=FlaskApiHandler)
-    mock_handler.get_blueprints.return_value = [flask_blueprint]
-    mock_handler.get_status_code.return_value = 420
-    mock_handler.get_route.return_value = ModelObject.new(
-        FlaskRoute,
+    return FlaskRouteAggregate.new(
         id='sample_route',
         rule='/sample',
         methods=['GET', 'POST'],
         status_code=269
     )
+
+# ** fixture: sample_blueprint_aggregate
+@pytest.fixture
+def sample_blueprint_aggregate(sample_route_aggregate: FlaskRouteAggregate) -> FlaskBlueprintAggregate:
+    '''
+    Fixture to provide a sample FlaskBlueprintAggregate.
+    '''
+
+    return FlaskBlueprintAggregate.new(
+        name='sample_blueprint',
+        routes=[sample_route_aggregate]
+    )
+
+# ** fixture: flask_api_context
+@pytest.fixture
+def flask_api_context(
+    sample_blueprint_aggregate: FlaskBlueprintAggregate,
+    sample_route_aggregate: FlaskRouteAggregate
+) -> FlaskApiContext:
+    '''
+    Fixture to provide a FlaskApiContext instance for testing.
+    '''
+
+    # Create mock contexts.
+    mock_features = mock.Mock(spec=FeatureContext)
+    mock_errors = mock.Mock(spec=ErrorContext)
+    mock_errors.handle_error.return_value = {'error_code': 'APP_ERROR', 'name': 'Application Error', 'message': 'An error occurred.'}
+    mock_logging = mock.Mock(spec=LoggingContext)
+
+    # Create mock callable handlers.
+    mock_get_blueprints = mock.Mock(return_value=[sample_blueprint_aggregate])
+    mock_get_route = mock.Mock(return_value=sample_route_aggregate)
+    mock_get_status_code = mock.Mock(return_value=420)
 
     # Create and return the FlaskApiContext instance.
     return FlaskApiContext(
@@ -73,7 +77,9 @@ def flask_api_context(flask_blueprint: FlaskBlueprint) -> FlaskApiContext:
         features=mock_features,
         errors=mock_errors,
         logging=mock_logging,
-        flask_api_handler=mock_handler
+        get_blueprints_handler=mock_get_blueprints,
+        get_route_handler=mock_get_route,
+        get_status_code_handler=mock_get_status_code,
     )
 
 # *** tests
@@ -107,7 +113,7 @@ def test_flask_api_parse_request(flask_api_context: FlaskApiContext):
 # ** test: flask_api_context_handle_error
 def test_flask_api_context_handle_error(flask_api_context: FlaskApiContext):
     '''
-    Test the handle_error method of FlaskApiContext.
+    Test the handle_error method with a non-TiferetError exception.
 
     :param flask_api_context: A FlaskApiContext instance.
     :type flask_api_context: FlaskApiContext
@@ -116,18 +122,18 @@ def test_flask_api_context_handle_error(flask_api_context: FlaskApiContext):
     # Create a sample exception.
     sample_exception = Exception('Sample error')
 
-    # Create a Flask app context for jsonify to work.
-    with Flask(__name__).app_context():
-        response, status_code = flask_api_context.handle_error(sample_exception)
+    # Handle the error.
+    response, status_code = flask_api_context.handle_error(sample_exception)
 
-        # Assert that the response is a tuple of (response, status_code).
-        assert response.json == {'message': 'An error occurred.'}
-        assert status_code == 500
+    # Assert that the status code is 500 for generic errors.
+    assert isinstance(response, dict)
+    assert response['error_code'] == 'APP_ERROR'
+    assert status_code == 500
 
 # ** test: flask_api_context_handle_tiferet_error
 def test_flask_api_context_handle_tiferet_error(flask_api_context: FlaskApiContext):
     '''
-    Test the handle_error method of FlaskApiContext with a TiferetError.
+    Test the handle_error method with a TiferetError.
 
     :param flask_api_context: A FlaskApiContext instance.
     :type flask_api_context: FlaskApiContext
@@ -137,24 +143,38 @@ def test_flask_api_context_handle_tiferet_error(flask_api_context: FlaskApiConte
     sample_tiferet_error = TiferetError('TEST_ERROR', 'A test Tiferet error occurred.')
 
     # Mock the error handler to return a specific response.
-    flask_api_context.errors.handle_error.return_value = {'error_code': 'TEST_ERROR', 'text': 'A test Tiferet error occurred.'}
+    flask_api_context.errors.handle_error.return_value = {
+        'error_code': 'TEST_ERROR',
+        'name': 'Test Error',
+        'message': 'A test Tiferet error occurred.'
+    }
 
-    # Create a Flask app context for jsonify to work.
-    with Flask(__name__).app_context():
-        # Call the handle_error method.
-        response, status_code = flask_api_context.handle_error(sample_tiferet_error)
+    # Call the handle_error method.
+    response, status_code = flask_api_context.handle_error(sample_tiferet_error)
 
-        # Assert that the response is a tuple of (response, status_code).
-        assert response.json == {
-            'error_code': 'TEST_ERROR',
-            'text': 'A test Tiferet error occurred.'
-        }
-        assert status_code == 420
+    # Assert the response and status code.
+    assert response == {
+        'error_code': 'TEST_ERROR',
+        'name': 'Test Error',
+        'message': 'A test Tiferet error occurred.'
+    }
+    assert status_code == 420
+
+    # Assert the handler was called with the correct error code.
+    flask_api_context.get_status_code_handler.assert_called_once_with(
+        error_code='TEST_ERROR'
+    )
 
 # ** test: flask_api_context_handle_response
 def test_flask_api_context_handle_response(flask_api_context: FlaskApiContext):
+    '''
+    Test the handle_response method.
 
-    # Create a new request context from the flask_api_context.
+    :param flask_api_context: A FlaskApiContext instance.
+    :type flask_api_context: FlaskApiContext
+    '''
+
+    # Create a new request context.
     request_context = flask_api_context.parse_request(
         headers={'Content-Type': 'application/json'},
         data={'key': 'value'},
@@ -167,17 +187,27 @@ def test_flask_api_context_handle_response(flask_api_context: FlaskApiContext):
     # Handle the response.
     response, status_code = flask_api_context.handle_response(request_context)
 
-    # Assert that the response is as expected.
+    # Assert the response and status code.
     assert response == {'result_key': 'result_value'}
     assert status_code == 269
 
+    # Assert the route handler was called with the feature id.
+    flask_api_context.get_route_handler.assert_called_once_with(
+        endpoint='test_feature'
+    )
+
 # ** test: flask_api_context_build_blueprint
-def test_flask_api_context_build_blueprint(flask_api_context: FlaskApiContext, flask_blueprint: FlaskBlueprint):
+def test_flask_api_context_build_blueprint(
+    flask_api_context: FlaskApiContext,
+    sample_blueprint_aggregate: FlaskBlueprintAggregate
+):
     '''
-    Test the build_blueprint method of FlaskApiContext.
+    Test the build_blueprint method.
 
     :param flask_api_context: A FlaskApiContext instance.
     :type flask_api_context: FlaskApiContext
+    :param sample_blueprint_aggregate: A sample blueprint aggregate.
+    :type sample_blueprint_aggregate: FlaskBlueprintAggregate
     '''
 
     # Create a sample view function.
@@ -186,11 +216,11 @@ def test_flask_api_context_build_blueprint(flask_api_context: FlaskApiContext, f
 
     # Build a sample blueprint.
     blueprint = flask_api_context.build_blueprint(
-        flask_blueprint=flask_blueprint,
+        flask_blueprint=sample_blueprint_aggregate,
         view_func=sample_view_func
     )
 
-    # Assert that the returned object is a FlaskBlueprint instance.
+    # Assert the blueprint was created correctly.
     assert isinstance(blueprint, Blueprint)
     assert blueprint.name == 'sample_blueprint'
     assert blueprint.url_prefix is None
@@ -198,7 +228,7 @@ def test_flask_api_context_build_blueprint(flask_api_context: FlaskApiContext, f
 # ** test: flask_api_context_build_flask_app
 def test_flask_api_context_build_flask_app(flask_api_context: FlaskApiContext):
     '''
-    Test the build_flask_app method of FlaskApiContext.
+    Test the build_flask_app method.
 
     :param flask_api_context: A FlaskApiContext instance.
     :type flask_api_context: FlaskApiContext
@@ -213,5 +243,8 @@ def test_flask_api_context_build_flask_app(flask_api_context: FlaskApiContext):
         view_func=sample_view_func
     )
 
-    # Assert that the returned object is a Flask instance.
+    # Assert the Flask app was created.
     assert isinstance(flask_api_context.flask_app, Flask)
+
+    # Assert the blueprints handler was called.
+    flask_api_context.get_blueprints_handler.assert_called_once()

--- a/tiferet_flask/contexts/tests/test_request.py
+++ b/tiferet_flask/contexts/tests/test_request.py
@@ -3,21 +3,26 @@
 # ** infra
 import pytest
 from tiferet import (
-    ModelObject,
+    DomainObject,
     StringType
 )
 
 # ** app
-from ..request import *
+from ..request import FlaskRequestContext
 
 # *** fixtures
 
 # ** fixture: request_context
 @pytest.fixture
-def request_context():
-    """Fixture to provide a mock FlaskRequestContext."""
+def request_context() -> FlaskRequestContext:
+    '''
+    Fixture to provide a FlaskRequestContext for testing.
 
-    # Create a mock FlaskRequestContext.
+    :return: A FlaskRequestContext instance.
+    :rtype: FlaskRequestContext
+    '''
+
+    # Create a FlaskRequestContext.
     request_context = FlaskRequestContext(
         data=dict(
             key='value',
@@ -29,19 +34,19 @@ def request_context():
         feature_id='test_group.test_feature'
     )
 
-    # Return the mock FlaskRequestContext.
+    # Return the FlaskRequestContext.
     return request_context
 
 # *** tests
 
 # ** test: request_context_handle_response_none
-def test_request_context_handle_response_none(request_context):
-    """
-    Test handling a response that is None in the FlaskRequestContext.
+def test_request_context_handle_response_none(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is None.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
     # Set the request context result to None.
     request_context.set_result(None)
@@ -49,17 +54,17 @@ def test_request_context_handle_response_none(request_context):
     # Handle a None response.
     response = request_context.handle_response()
 
-    # Check that the response is None.
+    # Check that the response is empty string.
     assert response == ''
 
 # ** test: request_context_handle_response_primitive
-def test_request_context_handle_response_primitive(request_context):
-    """
-    Test handling a response that is a primitive type in the FlaskRequestContext.
+def test_request_context_handle_response_primitive(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is a primitive type.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
     # Set the request context result to a primitive type.
     request_context.set_result('test_string')
@@ -71,13 +76,13 @@ def test_request_context_handle_response_primitive(request_context):
     assert response == 'test_string'
 
 # ** test: request_context_handle_response_data
-def test_request_context_handle_response_data(request_context):
-    """
-    Test handling a response with data in the FlaskRequestContext.
+def test_request_context_handle_response_data(request_context: FlaskRequestContext):
+    '''
+    Test handling a response with dict data.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
     # Set the request context result to some data.
     request_context.result = {'key': 'value'}
@@ -88,41 +93,41 @@ def test_request_context_handle_response_data(request_context):
     # Check that the response is as expected.
     assert response == {'key': 'value'}
 
-# ** test: request_context_handle_response_model_object
-def test_request_context_handle_response_model_object(request_context):
-    """
-    Test handling a response that is a ModelObject in the FlaskRequestContext.
+# ** test: request_context_handle_response_domain_object
+def test_request_context_handle_response_domain_object(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is a DomainObject.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
-    # Create a ModelObject to simulate a response.
-    class Data(ModelObject):
+    # Create a DomainObject to simulate a response.
+    class Data(DomainObject):
 
         key = StringType(
             default='default_value',
             required=True
         )
 
-    # Set the request context result to a ModelObject.
-    request_context.set_result(ModelObject.new(Data, key='value'))
+    # Set the request context result to a DomainObject.
+    request_context.set_result(DomainObject.new(Data, key='value'))
 
-    # Handle the response with a ModelObject.
+    # Handle the response with a DomainObject.
     response = request_context.handle_response()
 
-    # Check that the response is a ModelObject and has the expected data.
+    # Check that the response is a dict with expected data.
     assert isinstance(response, dict)
     assert response.get('key') == 'value'
 
 # ** test: request_context_handle_response_list
-def test_request_context_handle_response_list(request_context):
-    """
-    Test handling a response that is a list in the FlaskRequestContext.
+def test_request_context_handle_response_list(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is a plain list.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
     # Set the request context result to a list.
     request_context.result = ['item1', 'item2', 'item3']
@@ -134,65 +139,65 @@ def test_request_context_handle_response_list(request_context):
     assert isinstance(response, list)
     assert response == ['item1', 'item2', 'item3']
 
-# ** test: request_context_handle_response_model_list
-def test_request_context_handle_response_model_list(request_context):
-    """
-    Test handling a response that is a list of ModelObjects in the FlaskRequestContext.
+# ** test: request_context_handle_response_domain_object_list
+def test_request_context_handle_response_domain_object_list(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is a list of DomainObjects.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
-    # Create a ModelObject to simulate a response.
-    class Item(ModelObject):
+    # Create a DomainObject to simulate a response.
+    class Item(DomainObject):
 
         name = StringType(
             default='default_name',
             required=True
         )
 
-    # Set the request context result to a list of ModelObjects.
+    # Set the request context result to a list of DomainObjects.
     request_context.set_result([
-        ModelObject.new(Item, name='item1'),
-        ModelObject.new(Item, name='item2')
+        DomainObject.new(Item, name='item1'),
+        DomainObject.new(Item, name='item2')
     ])
 
-    # Handle the response with a list of ModelObjects.
+    # Handle the response with a list of DomainObjects.
     response = request_context.handle_response()
 
-    # Check that the response is a list and contains ModelObjects with expected names.
+    # Check that the response is a list of dicts.
     assert isinstance(response, list)
     assert len(response) == 2
     assert response[0].get('name') == 'item1'
     assert response[1].get('name') == 'item2'
 
-# ** test: request_context_handle_response_model_dict
-def test_request_context_handle_response_model_dict(request_context):
-    """
-    Test handling a response that is a dict of ModelObjects in the FlaskRequestContext.
+# ** test: request_context_handle_response_domain_object_dict
+def test_request_context_handle_response_domain_object_dict(request_context: FlaskRequestContext):
+    '''
+    Test handling a response that is a dict of DomainObjects.
 
     :param request_context: The FlaskRequestContext instance.
     :type request_context: FlaskRequestContext
-    """
+    '''
 
-    # Create a ModelObject to simulate a response.
-    class Item(ModelObject):
+    # Create a DomainObject to simulate a response.
+    class Item(DomainObject):
 
         name = StringType(
             default='default_name',
             required=True
         )
 
-    # Set the request context result to a dict of ModelObjects.
+    # Set the request context result to a dict of DomainObjects.
     request_context.set_result({
-        'item1': ModelObject.new(Item, name='item1'),
-        'item2': ModelObject.new(Item, name='item2')
+        'item1': DomainObject.new(Item, name='item1'),
+        'item2': DomainObject.new(Item, name='item2')
     })
 
-    # Handle the response with a dict of ModelObjects.
+    # Handle the response with a dict of DomainObjects.
     response = request_context.handle_response()
 
-    # Check that the response is a dict and contains ModelObjects with expected names.
+    # Check that the response is a dict of dicts.
     assert isinstance(response, dict)
     assert len(response) == 2
     assert response['item1'].get('name') == 'item1'


### PR DESCRIPTION
## Summary

Implements issue #18 — Context Refactor & Asset Updates for the tiferet-flask v0.2 migration.

### Changes
- **`contexts/request.py`**: Migrated `ModelObject` → `DomainObject` (import + all isinstance checks).
- **`contexts/flask.py`**: Replaced `FlaskApiHandler` dependency with three injectable callable handlers (`get_blueprints_handler`, `get_route_handler`, `get_status_code_handler`). `handle_error` now catches `TiferetAPIError` from parent and returns a dict + status code tuple.
- **`tiferet_flask/__init__.py`**: Updated export from `.models` → `.domain`, version bumped to `0.2.0`.
- **Tests**: 13 passing context tests with updated mocking patterns (callable handlers, `TiferetAPIError` format).

### Deviation from TRD
- `handle_error` required catching `TiferetAPIError` raised by the parent `AppInterfaceContext.handle_error()`, which was not anticipated in the TRD. The implementation wraps the parent call in a try/except and returns the API error fields as a dict.

Closes #18

---
[Conversation](https://app.warp.dev/conversation/68a42dc4-590a-40c8-876b-6498071e1ee5)

Co-Authored-By: Oz <oz-agent@warp.dev>