### PR TITLE
Version Bump, Documentation & Guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md — Tiferet Flask (v0.2.0)
+
+## Project Overview
+
+**Tiferet Flask** is an extension of the Tiferet framework for building Flask-based APIs using Domain-Driven Design (DDD). It provides `FlaskApiContext`, `FlaskRequestContext`, domain objects, domain events, and a YAML-backed repository for Flask configuration.
+
+- **Repository:** https://github.com/greatstrength/tiferet-flask
+- **Branch:** `main`
+- **Python:** ≥ 3.10
+- **Version:** `0.2.0`
+- **Dependencies:** `tiferet >= 2.0.0a8`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
+
+## Architecture
+
+### Package Layout
+
+```
+tiferet_flask/
+├── __init__.py          — Version and public exports
+├── domain/              — FlaskRoute, FlaskBlueprint (DomainObject)
+├── interfaces/          — FlaskApiService (Service)
+├── mappers/             — Aggregates and TransferObjects for YAML round-trip
+├── repos/               — FlaskYamlRepository (YAML-backed FlaskApiService)
+├── events/              — GetFlaskBlueprints, GetFlaskRoute, GetFlaskStatusCode (DomainEvent)
+└── contexts/            — FlaskApiContext (AppInterfaceContext), FlaskRequestContext (RequestContext)
+```
+
+### Key Concepts
+
+- **Domain Objects** (`domain/flask.py`): `FlaskRoute` and `FlaskBlueprint` — read-only domain models extending `DomainObject`.
+- **Service Interface** (`interfaces/flask.py`): `FlaskApiService` — abstract contract for Flask API configuration access (exists, get_blueprints, get_route, get_status_code, save, delete).
+- **Mappers** (`mappers/flask.py`): `FlaskRouteAggregate`, `FlaskBlueprintAggregate` (mutable), `FlaskRouteYamlObject`, `FlaskBlueprintYamlObject` (serialization).
+- **Repository** (`repos/flask.py`): `FlaskYamlRepository` — YAML-backed implementation of `FlaskApiService` using the `Yaml` utility.
+- **Domain Events** (`events/flask.py`): `GetFlaskBlueprints`, `GetFlaskRoute`, `GetFlaskStatusCode` — receive `FlaskApiService` via constructor injection.
+- **Contexts** (`contexts/flask.py`): `FlaskApiContext` — receives three callable handlers (`get_blueprints_handler`, `get_route_handler`, `get_status_code_handler`) resolved by the DI container.
+
+### Runtime Flow
+
+1. `App()` loads settings and resolves the `calc_flask_api` interface.
+2. `FlaskApiContext` is instantiated with callable handlers backed by domain events.
+3. `build_flask_app()` calls `get_blueprints_handler()` to load blueprints and register Flask routes.
+4. On request, `view_func` calls `context.run()` which parses the request, executes the feature, and returns a response with status code.
+5. `handle_error` catches `TiferetAPIError` from the parent and returns a dict + status code tuple.
+
+## Structured Code Style
+
+All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`). See the [tiferet AGENTS.md](https://github.com/greatstrength/tiferet) for the full style guide.
+
+## Testing
+
+- **Framework:** `pytest`
+- **Test location:** Co-located in `<package>/tests/` directories.
+- **Run tests:** `pytest tiferet_flask/ -v`
+- **Patterns:**
+  - Domain/mapper tests use `DomainObject.new()` and `Aggregate.new()`.
+  - Event tests use `DomainEvent.handle()` with mocked `FlaskApiService`.
+  - Repo tests are integration tests using `tmp_path` with real YAML files.
+  - Context tests use `mock.Mock()` callables for handler dependencies.
+
+## Key Files
+
+- `tiferet_flask/__init__.py` — Version and public exports
+- `tiferet_flask/domain/flask.py` — FlaskRoute, FlaskBlueprint domain objects
+- `tiferet_flask/interfaces/flask.py` — FlaskApiService interface
+- `tiferet_flask/mappers/flask.py` — Aggregates and TransferObjects
+- `tiferet_flask/repos/flask.py` — FlaskYamlRepository
+- `tiferet_flask/events/flask.py` — Domain events
+- `tiferet_flask/contexts/flask.py` — FlaskApiContext
+- `tiferet_flask/contexts/request.py` — FlaskRequestContext

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-Tiferet Flask elevates the Tiferet Python framework by empowering developers to craft sophisticated Flask-based APIs rooted in Domain-Driven Design (DDD) principles. Drawing from the Kabbalistic ideal of beauty in harmony, Tiferet Flask seamlessly blends Tiferet’s command-driven architecture with Flask’s intuitive routing and request handling. The result is a powerful, modular platform for building scalable web services that distill complex business logic into elegant, extensible API designs.
+Tiferet Flask elevates the Tiferet Python framework by empowering developers to craft sophisticated Flask-based APIs rooted in Domain-Driven Design (DDD) principles. Drawing from the Kabbalistic ideal of beauty in harmony, Tiferet Flask seamlessly blends Tiferet's domain event-driven architecture with Flask's intuitive routing and request handling. The result is a powerful, modular platform for building scalable web services that distill complex business logic into elegant, extensible API designs.
 
-This tutorial walks you through creating a streamlined calculator API, leveraging Tiferet’s robust commands and configurations while introducing Flask-specific interfaces and endpoints. For a deeper understanding of Tiferet’s foundational concepts, consult the [Tiferet documentation](https://github.com/greatstrength/tiferet).
+This tutorial walks you through creating a streamlined calculator API, leveraging Tiferet's robust domain events and configurations while introducing Flask-specific interfaces and endpoints. For a deeper understanding of Tiferet's foundational concepts, consult the [Tiferet documentation](https://github.com/greatstrength/tiferet).
 
 ## Getting Started with Tiferet Flask
 
-Embark on your Tiferet Flask journey by preparing your development environment. This guide assumes familiarity with Tiferet’s core setup.
+Embark on your Tiferet Flask journey by preparing your development environment. This guide assumes familiarity with Tiferet's core setup.
 
 ### Installing Python
 
@@ -63,7 +63,7 @@ Note: If developing locally, replace with the appropriate local installation com
 
 ### Project Structure
 
-Adapt Tiferet’s project structure to incorporate Flask, adding a dedicated API script:
+Adapt Tiferet's project structure to incorporate Flask, adding a dedicated API script:
 
 ```plaintext
 project_root/
@@ -71,7 +71,7 @@ project_root/
 ├── calc_cli.py
 ├── calc_flask_api.py
 ├── app/
-    ├── commands/
+    ├── events/
     │   ├── __init__.py
     │   ├── calc.py
     │   └── settings.py
@@ -85,19 +85,19 @@ project_root/
         └── logging.yml
 ```
 
-The `app/commands/` and `app/configs/` directories align with Tiferet’s structure (see [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#project-structure)). The `calc_flask_api.py` script initializes and runs the Flask API, while `flask.yml` defines blueprint and routing configurations.
+The `app/events/` and `app/configs/` directories align with Tiferet's structure (see [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#project-structure)). The `calc_flask_api.py` script initializes and runs the Flask API, while `flask.yml` defines blueprint and routing configurations.
 
 ## Crafting the Calculator API
 
-Extend Tiferet’s calculator application into a powerful API by reusing its commands and configurations, enhanced with Flask-specific functionality.
+Extend Tiferet's calculator application into a powerful API by reusing its domain events and configurations, enhanced with Flask-specific functionality.
 
-### Defining Base and Arithmetic Command Classes
+### Defining Base and Arithmetic Domain Event Classes
 
-Leverage Tiferet’s `BasicCalcCommand` (`app/commands/settings.py`) for input validation and arithmetic commands (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber` in `app/commands/calc.py`) for core operations. These remain unchanged from the original calculator app; refer to the [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#defining-base-and-arithmetic-command-classes) for details.
+Leverage Tiferet's `BasicCalcEvent` (`app/events/settings.py`) for input validation and arithmetic domain events (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber` in `app/events/calc.py`) for core operations. These remain unchanged from the original calculator app; refer to the [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#defining-base-and-arithmetic-domain-event-classes) for details.
 
 ### Configuring the Calculator API
 
-Reuse Tiferet’s `container.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-container-in-configscontaineryml)), `error.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-errors-in-configserroryml)), and `feature.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-features-in-configsfeatureyml)) for command mappings, error handling, and feature workflows. Introduce a Flask-specific interface in `app.yml` and routing configurations in `flask.yml`.
+Reuse Tiferet's `container.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-container-in-configscontaineryml)), `error.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-errors-in-configserroryml)), and `feature.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-features-in-configsfeatureyml)) for domain event mappings, error handling, and feature workflows. Introduce a Flask-specific interface in `app.yml` and routing configurations in `flask.yml`.
 
 #### Configuring the App Interface in `configs/app.yml`
 
@@ -111,12 +111,18 @@ interfaces:
     module_path: tiferet_flask.contexts.flask
     class_name: FlaskApiContext
     attrs:
-      flask_api_handler:
-        module_path: tiferet_flask.handlers.flask
-        class_name: FlaskApiHandler
-      flask_repo:
-        module_path: tiferet_flask.proxies.yaml.flask
-        class_name: FlaskYamlProxy
+      get_blueprints_handler:
+        module_path: tiferet_flask.events.flask
+        class_name: GetFlaskBlueprints
+      get_route_handler:
+        module_path: tiferet_flask.events.flask
+        class_name: GetFlaskRoute
+      get_status_code_handler:
+        module_path: tiferet_flask.events.flask
+        class_name: GetFlaskStatusCode
+      flask_service:
+        module_path: tiferet_flask.repos.flask
+        class_name: FlaskYamlRepository
         params:
           flask_config_file: app/configs/flask.yml
 ```
@@ -257,4 +263,4 @@ curl -X POST http://127.0.0.1:5000/calc/divide -H "Content-Type: application/jso
 
 ## Conclusion
 
-Tiferet Flask empowers developers to craft elegant, modular Flask APIs within Tiferet’s DDD framework, as showcased in this calculator tutorial. By seamlessly reusing Tiferet’s commands and configurations and introducing a Flask interface, you’ve built a scalable, intuitive API with minimal effort. Expand its capabilities by integrating authentication, advanced features like trigonometric operations, or combining with Tiferet’s CLI or TUI contexts. Dive into the [Tiferet documentation](https://github.com/greatstrength/tiferet) for advanced DDD techniques, and experiment with `app/configs/` to customize your API, transforming complex web applications—whether monolithic or networked—into clear, purposeful solutions.
+Tiferet Flask empowers developers to craft elegant, modular Flask APIs within Tiferet's DDD framework, as showcased in this calculator tutorial. By seamlessly reusing Tiferet's domain events and configurations and introducing a Flask interface, you've built a scalable, intuitive API with minimal effort. Expand its capabilities by integrating authentication, advanced features like trigonometric operations, or combining with Tiferet's CLI or TUI contexts. Dive into the [Tiferet documentation](https://github.com/greatstrength/tiferet) for advanced DDD techniques, and experiment with `app/configs/` to customize your API, transforming complex web applications—whether monolithic or networked—into clear, purposeful solutions.

--- a/docs/guides/domain/flask_blueprint.md
+++ b/docs/guides/domain/flask_blueprint.md
@@ -1,0 +1,41 @@
+# FlaskBlueprint
+
+**Package:** `tiferet_flask.domain.flask`
+**Base Class:** `DomainObject`
+
+## Description
+
+Represents a Flask blueprint containing a collection of routes. A `FlaskBlueprint` groups related API endpoints under a common name and optional URL prefix.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | `StringType` | Yes | — | The name of the blueprint. |
+| `url_prefix` | `StringType` | No | `None` | The URL prefix for all routes in this blueprint. |
+| `routes` | `ListType(ModelType(FlaskRoute))` | No | `[]` | A list of routes associated with this blueprint. |
+
+## Instantiation
+
+```python
+from tiferet import DomainObject
+from tiferet_flask.domain import FlaskBlueprint, FlaskRoute
+
+blueprint = DomainObject.new(
+    FlaskBlueprint,
+    name='calc',
+    url_prefix='/calc',
+    routes=[
+        DomainObject.new(FlaskRoute, id='add', rule='/add', methods=['POST'])
+    ]
+)
+```
+
+## Usage
+
+`FlaskBlueprint` instances are consumed by `FlaskApiContext.build_flask_app()` to assemble the Flask application. The context iterates over blueprints returned by `get_blueprints_handler()`, builds each into a Flask `Blueprint`, and registers it with the Flask app.
+
+## See Also
+
+- [FlaskRoute](flask_route.md)
+- `tiferet_flask/mappers/flask.py` — `FlaskBlueprintAggregate`, `FlaskBlueprintYamlObject`

--- a/docs/guides/domain/flask_route.md
+++ b/docs/guides/domain/flask_route.md
@@ -1,0 +1,41 @@
+# FlaskRoute
+
+**Package:** `tiferet_flask.domain.flask`
+**Base Class:** `DomainObject`
+
+## Description
+
+Represents a single Flask route endpoint. A `FlaskRoute` defines the URL rule, allowed HTTP methods, and default status code for an API endpoint.
+
+## Attributes
+
+| Attribute | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `id` | `StringType` | Yes | — | The unique identifier of the route endpoint. |
+| `rule` | `StringType` | Yes | — | The URL rule as string (e.g., `/sample`). |
+| `methods` | `ListType(StringType)` | Yes | — | A list of HTTP methods this rule should be limited to. |
+| `status_code` | `IntegerType` | No | `200` | The default HTTP status code for the route response. |
+
+## Instantiation
+
+```python
+from tiferet import DomainObject
+from tiferet_flask.domain import FlaskRoute
+
+route = DomainObject.new(
+    FlaskRoute,
+    id='sample_route',
+    rule='/sample',
+    methods=['GET', 'POST'],
+    status_code=200
+)
+```
+
+## Usage
+
+`FlaskRoute` instances are consumed by `FlaskApiContext.build_blueprint()` to register URL rules on Flask blueprints. They are typically loaded from YAML configuration via `FlaskYamlRepository.get_blueprints()` as part of `FlaskBlueprint.routes`.
+
+## See Also
+
+- [FlaskBlueprint](flask_blueprint.md)
+- `tiferet_flask/mappers/flask.py` — `FlaskRouteAggregate`, `FlaskRouteYamlObject`

--- a/docs/guides/events/get_flask_blueprints.md
+++ b/docs/guides/events/get_flask_blueprints.md
@@ -1,0 +1,40 @@
+# GetFlaskBlueprints
+
+**Package:** `tiferet_flask.events.flask`
+**Base Class:** `DomainEvent`
+
+## Description
+
+Retrieves all Flask blueprints from the `FlaskApiService`. This event is used by `FlaskApiContext` during application startup to load blueprint configurations for route registration.
+
+## Dependencies
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `flask_service` | `FlaskApiService` | The Flask API service for configuration access. |
+
+## Parameters
+
+None required.
+
+## Returns
+
+`List[FlaskBlueprintAggregate]` — A list of all Flask blueprint aggregates.
+
+## Test Invocation
+
+```python
+from tiferet.events import DomainEvent
+from tiferet_flask.events import GetFlaskBlueprints
+
+result = DomainEvent.handle(
+    GetFlaskBlueprints,
+    dependencies={'flask_service': mock_flask_service},
+)
+```
+
+## See Also
+
+- [GetFlaskRoute](get_flask_route.md)
+- [GetFlaskStatusCode](get_flask_status_code.md)
+- `tiferet_flask/interfaces/flask.py` — `FlaskApiService`

--- a/docs/guides/events/get_flask_route.md
+++ b/docs/guides/events/get_flask_route.md
@@ -1,0 +1,56 @@
+# GetFlaskRoute
+
+**Package:** `tiferet_flask.events.flask`
+**Base Class:** `DomainEvent`
+
+## Description
+
+Retrieves a Flask route by its endpoint string. The endpoint is parsed to extract an optional blueprint name and route ID. If the route is not found, a `FLASK_ROUTE_NOT_FOUND` error is raised.
+
+## Dependencies
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `flask_service` | `FlaskApiService` | The Flask API service for configuration access. |
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `endpoint` | `str` | Yes | The endpoint identifier in format `blueprint_name.route_id` or just `route_id`. |
+
+Validated via `@DomainEvent.parameters_required(['endpoint'])`.
+
+## Behavior
+
+1. Parses the endpoint string — splits on `.` to extract `blueprint_name` and `route_id`. Falls back to `route_id` only if no `.` is present.
+2. Delegates to `flask_service.get_route(route_id, blueprint_name)`.
+3. Verifies the route exists via `self.verify()`. Raises `FLASK_ROUTE_NOT_FOUND` if `None`.
+
+## Returns
+
+`FlaskRouteAggregate` — The matching Flask route aggregate.
+
+## Errors
+
+| Error Code | Condition |
+|------------|-----------|
+| `FLASK_ROUTE_NOT_FOUND` | Route does not exist for the given endpoint. |
+
+## Test Invocation
+
+```python
+from tiferet.events import DomainEvent
+from tiferet_flask.events import GetFlaskRoute
+
+result = DomainEvent.handle(
+    GetFlaskRoute,
+    dependencies={'flask_service': mock_flask_service},
+    endpoint='calc.add',
+)
+```
+
+## See Also
+
+- [GetFlaskBlueprints](get_flask_blueprints.md)
+- [GetFlaskStatusCode](get_flask_status_code.md)

--- a/docs/guides/events/get_flask_status_code.md
+++ b/docs/guides/events/get_flask_status_code.md
@@ -1,0 +1,44 @@
+# GetFlaskStatusCode
+
+**Package:** `tiferet_flask.events.flask`
+**Base Class:** `DomainEvent`
+
+## Description
+
+Retrieves the HTTP status code mapped to a given error code. Used by `FlaskApiContext.handle_error()` to determine the appropriate HTTP response status for Tiferet errors.
+
+## Dependencies
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `flask_service` | `FlaskApiService` | The Flask API service for configuration access. |
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `error_code` | `str` | Yes | The error code identifier (e.g., `DIVIDE_BY_ZERO`). |
+
+Validated via `@DomainEvent.parameters_required(['error_code'])`.
+
+## Returns
+
+`int` — The corresponding HTTP status code. Defaults to `500` for unknown error codes.
+
+## Test Invocation
+
+```python
+from tiferet.events import DomainEvent
+from tiferet_flask.events import GetFlaskStatusCode
+
+result = DomainEvent.handle(
+    GetFlaskStatusCode,
+    dependencies={'flask_service': mock_flask_service},
+    error_code='DIVIDE_BY_ZERO',
+)
+```
+
+## See Also
+
+- [GetFlaskBlueprints](get_flask_blueprints.md)
+- [GetFlaskRoute](get_flask_route.md)


### PR DESCRIPTION
## Summary

Implements issue #20 — Version Bump, Documentation & Guides for tiferet-flask v0.2.0.

### Changes
- **`README.md`**: Updated to reflect v2 architecture — domain events (not commands), `FlaskApiService` (not handlers/proxies), updated `app.yml` example with callable handlers and `FlaskYamlRepository`.
- **`AGENTS.md`**: New file — project overview, package layout, key concepts, runtime flow, testing patterns, and key files for AI agents.
- **`docs/guides/domain/`**: New guides for `FlaskRoute` and `FlaskBlueprint` domain objects.
- **`docs/guides/events/`**: New guides for `GetFlaskBlueprints`, `GetFlaskRoute`, and `GetFlaskStatusCode` domain events.
- Version confirmed at `0.2.0` (set in TRD 4).
- No v1 class references remain in any documentation.

Closes #20

---
[Conversation](https://app.warp.dev/conversation/68a42dc4-590a-40c8-876b-6498071e1ee5)

Co-Authored-By: Oz <oz-agent@warp.dev>