### PR TITLE
Bug Fixes – Blueprint view_func Lambda Closure and FlaskRequestContext set_result data_key Support (#27)

### DIFF
--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -14,4 +14,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tiferet_flask/contexts/flask.py
+++ b/tiferet_flask/contexts/flask.py
@@ -175,7 +175,7 @@ class FlaskApiContext(AppInterfaceContext):
                 route.rule,
                 route.id,
                 methods=route.methods,
-                view_func=lambda: view_func(self, **kwargs),
+                view_func=view_func,
             )
 
         # Return the created blueprint.

--- a/tiferet_flask/contexts/request.py
+++ b/tiferet_flask/contexts/request.py
@@ -31,13 +31,20 @@ class FlaskRequestContext(RequestContext):
         return super().handle_response()
 
     # * method: set_result
-    def set_result(self, result: Any):
+    def set_result(self, result: Any, data_key: str = None):
         '''
         Set the result of the request context.
 
         :param result: The result to set.
         :type result: Any
+        :param data_key: The key in the request data to set the result to. If provided, delegates to the parent method.
+        :type data_key: str
         '''
+
+        # If a data key is provided, delegate to the parent method.
+        if data_key:
+            super().set_result(result, data_key)
+            return
 
         # If the response is None, return an empty response.
         if result is None:

--- a/tiferet_flask/contexts/tests/test_flask.py
+++ b/tiferet_flask/contexts/tests/test_flask.py
@@ -225,6 +225,40 @@ def test_flask_api_context_build_blueprint(
     assert blueprint.name == 'sample_blueprint'
     assert blueprint.url_prefix is None
 
+# ** test: flask_api_context_build_blueprint_view_func_direct
+def test_flask_api_context_build_blueprint_view_func_direct(
+    flask_api_context: FlaskApiContext,
+    sample_blueprint_aggregate: FlaskBlueprintAggregate
+):
+    '''
+    Test that build_blueprint passes view_func directly to add_url_rule,
+    not wrapped in a lambda.
+
+    :param flask_api_context: A FlaskApiContext instance.
+    :type flask_api_context: FlaskApiContext
+    :param sample_blueprint_aggregate: A sample blueprint aggregate.
+    :type sample_blueprint_aggregate: FlaskBlueprintAggregate
+    '''
+
+    # Create a sample view function.
+    def sample_view_func():
+        return 'Sample Response'
+
+    # Build a sample blueprint.
+    blueprint = flask_api_context.build_blueprint(
+        flask_blueprint=sample_blueprint_aggregate,
+        view_func=sample_view_func
+    )
+
+    # Get the registered view functions from the blueprint's deferred functions.
+    # Register the blueprint on a temporary Flask app to resolve deferred registrations.
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+
+    # Assert the view function is the original function, not a lambda wrapper.
+    registered_view_func = app.view_functions.get('sample_blueprint.sample_route')
+    assert registered_view_func is sample_view_func
+
 # ** test: flask_api_context_build_flask_app
 def test_flask_api_context_build_flask_app(flask_api_context: FlaskApiContext):
     '''

--- a/tiferet_flask/contexts/tests/test_request.py
+++ b/tiferet_flask/contexts/tests/test_request.py
@@ -171,6 +171,23 @@ def test_request_context_handle_response_domain_object_list(request_context: Fla
     assert response[0].get('name') == 'item1'
     assert response[1].get('name') == 'item2'
 
+# ** test: request_context_set_result_with_data_key
+def test_request_context_set_result_with_data_key(request_context: FlaskRequestContext):
+    '''
+    Test that set_result with a data_key delegates to the parent method,
+    storing the result in request.data[data_key] instead of self.result.
+
+    :param request_context: The FlaskRequestContext instance.
+    :type request_context: FlaskRequestContext
+    '''
+
+    # Set the result with a data_key.
+    request_context.set_result('intermediate_value', data_key='step_result')
+
+    # Assert the result is stored in data, not in self.result.
+    assert request_context.data['step_result'] == 'intermediate_value'
+    assert request_context.result is None
+
 # ** test: request_context_handle_response_domain_object_dict
 def test_request_context_handle_response_domain_object_dict(request_context: FlaskRequestContext):
     '''


### PR DESCRIPTION
## Summary

Fixes two bugs in the `tiferet_flask` contexts package (closes #27).

### 1. `build_blueprint` Lambda Closure Bug
`FlaskApiContext.build_blueprint` was wrapping `view_func` in a lambda when passing it to `add_url_rule`, which altered the callable signature and added unnecessary indirection. Now passes `view_func` directly.

### 2. `FlaskRequestContext.set_result` Missing `data_key` Support
The overridden `set_result` did not accept the `data_key` parameter from the parent `RequestContext.set_result`. When a feature step specified a `data_key`, the result was always formatted and stored in `self.result` instead of `self.data[data_key]`. Now delegates to the parent when `data_key` is provided.

### Additional
- Version bumped from `0.2.0` to `0.2.1`.
- Added tests for both fixes.

## Files Changed
- `tiferet_flask/contexts/flask.py` — Removed lambda wrapper in `build_blueprint`
- `tiferet_flask/contexts/request.py` — Added `data_key` parameter to `set_result`
- `tiferet_flask/__init__.py` — Version bump
- `tiferet_flask/contexts/tests/test_flask.py` — Added `test_flask_api_context_build_blueprint_view_func_direct`
- `tiferet_flask/contexts/tests/test_request.py` — Added `test_request_context_set_result_with_data_key`

## Artifacts
- [Conversation](https://app.warp.dev/conversation/ef92f975-d714-4ebb-848c-6ee086a330ef)
- [TRD](https://app.warp.dev/drive/notebook/cvFcg2pL3QMGH1P9aBqMXs)

Co-Authored-By: Oz <oz-agent@warp.dev>