### PR TITLE
Domain – Pydantic v2 Migration (#29)

### DIFF
--- a/tiferet_flask/domain/__init__.py
+++ b/tiferet_flask/domain/__init__.py
@@ -1,3 +1,5 @@
+"""Flask domain objects."""
+
 # *** imports
 
 # ** app

--- a/tiferet_flask/domain/flask.py
+++ b/tiferet_flask/domain/flask.py
@@ -1,13 +1,15 @@
+"""Flask domain models."""
+
 # *** imports
 
+# ** core
+from typing import List
+
 # ** infra
-from tiferet import (
-    DomainObject,
-    StringType,
-    IntegerType,
-    ListType,
-    ModelType
-)
+from pydantic import Field
+
+# ** app
+from tiferet.domain import DomainObject
 
 # *** models
 
@@ -18,36 +20,33 @@ class FlaskRoute(DomainObject):
     '''
 
     # * attribute: id
-    id = StringType(
-        required=True,
-        metadata=dict(
-            description='The unique identifier of the route endpoint.'
-        )
+    id: str = Field(
+        ...,
+        description='The unique identifier of the route.',
+    )
+
+    # * attribute: endpoint
+    endpoint: str = Field(
+        ...,
+        description='The fully-qualified endpoint (blueprint_name.route_id).',
     )
 
     # * attribute: rule
-    rule = StringType(
-        required=True,
-        metadata=dict(
-            description='The URL rule as string.'
-        )
+    rule: str = Field(
+        ...,
+        description='The URL rule as string.',
     )
 
     # * attribute: methods
-    methods = ListType(
-        StringType,
-        required=True,
-        metadata=dict(
-            description='A list of HTTP methods this rule should be limited to.'
-        )
+    methods: List[str] = Field(
+        ...,
+        description='HTTP methods this rule is limited to.',
     )
 
     # * attribute: status_code
-    status_code = IntegerType(
+    status_code: int = Field(
         default=200,
-        metadata=dict(
-            description='The default HTTP status code for the route response.'
-        )
+        description='The default HTTP status code for the route response.',
     )
 
 # ** model: flask_blueprint
@@ -57,25 +56,19 @@ class FlaskBlueprint(DomainObject):
     '''
 
     # * attribute: name
-    name = StringType(
-        required=True,
-        metadata=dict(
-            description='The name of the blueprint.'
-        )
+    name: str = Field(
+        ...,
+        description='The name of the blueprint.',
     )
 
     # * attribute: url_prefix
-    url_prefix = StringType(
-        metadata=dict(
-            description='The URL prefix for all routes in this blueprint.'
-        )
+    url_prefix: str | None = Field(
+        default=None,
+        description='The URL prefix for all routes in this blueprint.',
     )
 
     # * attribute: routes
-    routes = ListType(
-        ModelType(FlaskRoute),
-        default=[],
-        metadata=dict(
-            description='A list of routes associated with this blueprint.'
-        )
+    routes: List[FlaskRoute] = Field(
+        default_factory=list,
+        description='A list of routes associated with this blueprint.',
     )

--- a/tiferet_flask/domain/tests/test_flask.py
+++ b/tiferet_flask/domain/tests/test_flask.py
@@ -2,7 +2,6 @@
 
 # ** infra
 import pytest
-from tiferet import DomainObject
 
 # ** app
 from ..flask import FlaskRoute, FlaskBlueprint
@@ -19,12 +18,12 @@ def flask_route() -> FlaskRoute:
     :rtype: FlaskRoute
     '''
 
-    return DomainObject.new(
-        FlaskRoute,
+    return FlaskRoute(
         id='sample_route',
+        endpoint='sample_blueprint.sample_route',
         rule='/sample',
         methods=['GET', 'POST'],
-        status_code=200
+        status_code=200,
     )
 
 # ** fixture: flask_blueprint
@@ -39,10 +38,9 @@ def flask_blueprint(flask_route: FlaskRoute) -> FlaskBlueprint:
     :rtype: FlaskBlueprint
     '''
 
-    return DomainObject.new(
-        FlaskBlueprint,
+    return FlaskBlueprint(
         name='sample_blueprint',
-        routes=[flask_route]
+        routes=[flask_route],
     )
 
 # *** tests
@@ -57,9 +55,25 @@ def test_flask_route_creation(flask_route: FlaskRoute):
     '''
 
     assert flask_route.id == 'sample_route'
+    assert flask_route.endpoint == 'sample_blueprint.sample_route'
     assert flask_route.rule == '/sample'
     assert flask_route.methods == ['GET', 'POST']
     assert flask_route.status_code == 200
+
+# ** test: flask_route_default_status_code
+def test_flask_route_default_status_code():
+    '''
+    Test that FlaskRoute defaults status_code to 200.
+    '''
+
+    route = FlaskRoute(
+        id='default_route',
+        endpoint='bp.default_route',
+        rule='/default',
+        methods=['GET'],
+    )
+
+    assert route.status_code == 200
 
 # ** test: flask_blueprint_creation
 def test_flask_blueprint_creation(flask_blueprint: FlaskBlueprint, flask_route: FlaskRoute):
@@ -73,5 +87,17 @@ def test_flask_blueprint_creation(flask_blueprint: FlaskBlueprint, flask_route: 
     '''
 
     assert flask_blueprint.name == 'sample_blueprint'
+    assert flask_blueprint.url_prefix is None
     assert len(flask_blueprint.routes) == 1
     assert flask_blueprint.routes[0] == flask_route
+
+# ** test: flask_blueprint_defaults
+def test_flask_blueprint_defaults():
+    '''
+    Test that FlaskBlueprint defaults url_prefix to None and routes to empty list.
+    '''
+
+    blueprint = FlaskBlueprint(name='empty_blueprint')
+
+    assert blueprint.url_prefix is None
+    assert blueprint.routes == []


### PR DESCRIPTION
## Summary
Migrate `FlaskRoute` and `FlaskBlueprint` domain objects from Schematics type descriptors to Pydantic v2 `Field` annotations, aligning with `tiferet>=2.0.0b1`.

### Changes
- **`domain/flask.py`** — Replaced Schematics imports with Pydantic v2 `Field` annotations. Added `endpoint` field to `FlaskRoute`. Added module-level docstring.
- **`domain/__init__.py`** — Added module-level docstring header.
- **`domain/tests/test_flask.py`** — Replaced `DomainObject.new()` with direct Pydantic constructors. Added tests for `endpoint` field and `FlaskBlueprint` defaults.

Closes #29

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>