### PR TITLE
Mappers – Pydantic v2 Migration (#30)

### DIFF
--- a/tiferet_flask/mappers/__init__.py
+++ b/tiferet_flask/mappers/__init__.py
@@ -1,3 +1,5 @@
+"""Flask mappers."""
+
 # *** imports
 
 # ** app

--- a/tiferet_flask/mappers/flask.py
+++ b/tiferet_flask/mappers/flask.py
@@ -1,22 +1,21 @@
+"""Flask mappers."""
+
 # *** imports
 
 # ** core
-from typing import Dict, Any, List
+from typing import Any, ClassVar, Dict, List
 
 # ** infra
-from tiferet import (
-    DomainObject,
-    StringType,
-    DictType,
-    ModelType,
-    Aggregate,
-    TransferObject
-)
+from pydantic import Field
 
 # ** app
 from ..domain import (
     FlaskRoute,
-    FlaskBlueprint
+    FlaskBlueprint,
+)
+from tiferet.mappers import (
+    Aggregate,
+    TransferObject,
 )
 
 # *** mappers
@@ -24,83 +23,55 @@ from ..domain import (
 # ** mapper: flask_route_aggregate
 class FlaskRouteAggregate(FlaskRoute, Aggregate):
     '''
-    A mutable aggregate for Flask route domain objects.
+    Aggregate for the FlaskRoute domain object.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'FlaskRouteAggregate':
-        '''
-        Initializes a new Flask route aggregate.
-
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new Flask route aggregate.
-        :rtype: FlaskRouteAggregate
-        '''
-
-        # Create a new Flask route aggregate.
-        return Aggregate.new(
-            FlaskRouteAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
-        )
+    pass
 
 # ** mapper: flask_blueprint_aggregate
 class FlaskBlueprintAggregate(FlaskBlueprint, Aggregate):
     '''
-    A mutable aggregate for Flask blueprint domain objects.
+    Aggregate for the FlaskBlueprint domain object.
     '''
 
-    # * method: new
-    @staticmethod
-    def new(
-        validate: bool = True,
-        strict: bool = True,
-        **kwargs
-    ) -> 'FlaskBlueprintAggregate':
+    # * method: add_route
+    def add_route(self,
+            endpoint: str,
+            rule: str,
+            methods: List[str],
+            status_code: int = 200,
+        ) -> FlaskRouteAggregate:
         '''
-        Initializes a new Flask blueprint aggregate.
+        Add a new route to the blueprint.
 
-        :param validate: True to validate the aggregate object.
-        :type validate: bool
-        :param strict: True to enforce strict mode.
-        :type strict: bool
-        :param kwargs: Keyword arguments.
-        :type kwargs: dict
-        :return: A new Flask blueprint aggregate.
-        :rtype: FlaskBlueprintAggregate
+        :param endpoint: The unique identifier of the route endpoint.
+        :type endpoint: str
+        :param rule: The URL rule as string.
+        :type rule: str
+        :param methods: A list of HTTP methods this rule should be limited to.
+        :type methods: List[str]
+        :param status_code: The default HTTP status code for the route response.
+        :type status_code: int
+        :return: The created route aggregate.
+        :rtype: FlaskRouteAggregate
         '''
 
-        # Create a new Flask blueprint aggregate.
-        return Aggregate.new(
-            FlaskBlueprintAggregate,
-            validate=validate,
-            strict=strict,
-            **kwargs
+        # Create the route aggregate.
+        route = FlaskRouteAggregate(
+            id=endpoint,
+            endpoint=f'{self.name}.{endpoint}',
+            rule=rule,
+            methods=methods,
+            status_code=status_code,
         )
 
-    # * method: add_route
-    def add_route(self, route: FlaskRoute) -> None:
-        '''
-        Add a route to the blueprint.
+        # Copy routes to a local list, append, and reassign.
+        routes = list(self.routes)
+        routes.append(route)
+        self.routes = routes
 
-        :param route: The route to add.
-        :type route: FlaskRoute
-        '''
-
-        # Append the route and validate.
-        self.routes.append(route)
-        self.validate()
+        # Return the created route.
+        return route
 
     # * method: remove_route
     def remove_route(self, route_id: str) -> None:
@@ -111,150 +82,138 @@ class FlaskBlueprintAggregate(FlaskBlueprint, Aggregate):
         :type route_id: str
         '''
 
-        # Filter out the route with the specified ID.
+        # Filter out the route with the specified ID and reassign.
         self.routes = [r for r in self.routes if r.id != route_id]
-        self.validate()
 
 # ** mapper: flask_route_yaml_object
 class FlaskRouteYamlObject(FlaskRoute, TransferObject):
     '''
-    A YAML transfer object for Flask route data.
+    A YAML data representation of a FlaskRoute object.
     '''
 
-    class Options():
-        '''
-        Options for the transfer object.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.allow(),
-            'to_data': TransferObject.deny('id')
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {},
+        'to_data.yaml': {'exclude': {'id', 'endpoint'}},
+    }
 
     # * attribute: id
-    id = StringType(
-        metadata=dict(
-            description='The unique identifier of the route endpoint.'
-        )
+    id: str | None = Field(
+        default=None,
+        description='The unique identifier of the route (provided via dict key during mapping).',
+    )
+
+    # * attribute: endpoint
+    endpoint: str | None = Field(
+        default=None,
+        description='The fully-qualified endpoint (blueprint_name.route_id).',
     )
 
     # * method: map
-    def map(self, **kwargs) -> FlaskRouteAggregate:
+    def map(self, id: str = None, endpoint: str = None, **overrides) -> FlaskRouteAggregate:
         '''
         Map the YAML data to a FlaskRouteAggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A Flask route aggregate.
+        :param id: The route identifier override.
+        :type id: str
+        :param endpoint: The endpoint override.
+        :type endpoint: str
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new FlaskRouteAggregate.
         :rtype: FlaskRouteAggregate
         '''
 
-        # Map the transfer object to an aggregate.
+        # Map to the route aggregate with overrides.
         return super().map(
             FlaskRouteAggregate,
-            **kwargs
+            id=id,
+            endpoint=endpoint,
+            **overrides,
         )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, route: FlaskRoute, **overrides) -> 'FlaskRouteYamlObject':
+        '''
+        Create a FlaskRouteYamlObject from a FlaskRoute model.
+
+        :param route: The FlaskRoute model.
+        :type route: FlaskRoute
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new FlaskRouteYamlObject.
+        :rtype: FlaskRouteYamlObject
+        '''
+
+        # Create from the model.
+        return super().from_model(route, **overrides)
 
 # ** mapper: flask_blueprint_yaml_object
 class FlaskBlueprintYamlObject(FlaskBlueprint, TransferObject):
     '''
-    A YAML transfer object for Flask blueprint data.
+    A YAML data representation of a FlaskBlueprint object.
     '''
 
-    class Options():
-        '''
-        Options for the transfer object.
-        '''
-
-        serialize_when_none = False
-        roles = {
-            'to_model': TransferObject.deny('routes'),
-            'to_data': TransferObject.deny('name')
-        }
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'routes'}},
+        'to_data.yaml': {'by_alias': True, 'exclude': {'name'}},
+    }
 
     # * attribute: name
-    name = StringType(
-        metadata=dict(
-            description='The name of the blueprint.'
-        )
+    name: str | None = Field(
+        default=None,
+        description='The name of the blueprint.',
     )
 
     # * attribute: routes
-    routes = DictType(
-        ModelType(FlaskRouteYamlObject),
-        default={},
-        metadata=dict(
-            description='A dictionary of route ID to FlaskRouteYamlObject instances.'
-        )
+    routes: Dict[str, FlaskRouteYamlObject] = Field(
+        default_factory=dict,
+        description='A dictionary of route ID to FlaskRouteYamlObject instances.',
     )
 
-    # * method: from_data
-    @staticmethod
-    def from_data(routes: Dict[str, Any] = {}, **kwargs) -> 'FlaskBlueprintYamlObject':
-        '''
-        Create a FlaskBlueprintYamlObject instance from raw data.
-
-        :param routes: A dictionary of route ID to route data.
-        :type routes: Dict[str, Any]
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A new FlaskBlueprintYamlObject instance.
-        :rtype: FlaskBlueprintYamlObject
-        '''
-
-        # Convert each route in the routes dictionary to a FlaskRouteYamlObject.
-        route_objs = {id: TransferObject.from_data(
-            FlaskRouteYamlObject,
-            id=id, **data
-        ) for id, data in routes.items()}
-
-        # Create the blueprint transfer object.
-        return TransferObject.from_data(
-            FlaskBlueprintYamlObject,
-            routes=route_objs,
-            **kwargs
-        )
-
     # * method: map
-    def map(self, **kwargs) -> FlaskBlueprintAggregate:
+    def map(self, **overrides) -> FlaskBlueprintAggregate:
         '''
         Map the YAML data to a FlaskBlueprintAggregate.
 
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A Flask blueprint aggregate.
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new FlaskBlueprintAggregate.
         :rtype: FlaskBlueprintAggregate
         '''
 
-        # Map routes from dict to list, passing the dict key as the route id.
+        # Map to the blueprint aggregate with nested route conversion.
         return super().map(
             FlaskBlueprintAggregate,
-            routes=[route.map(id=id) for id, route in self.routes.items()],
-            **kwargs
+            routes=[
+                route.map(id=id, endpoint=f'{self.name}.{id}')
+                for id, route in self.routes.items()
+            ],
+            **overrides,
         )
 
     # * method: from_model
-    @staticmethod
-    def from_model(blueprint: FlaskBlueprint, **kwargs) -> 'FlaskBlueprintYamlObject':
+    @classmethod
+    def from_model(cls, blueprint: FlaskBlueprint, **overrides) -> 'FlaskBlueprintYamlObject':
         '''
-        Creates a FlaskBlueprintYamlObject from a FlaskBlueprint aggregate.
+        Create a FlaskBlueprintYamlObject from a FlaskBlueprint model.
 
-        :param blueprint: The blueprint aggregate.
+        :param blueprint: The FlaskBlueprint model.
         :type blueprint: FlaskBlueprint
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
         :return: A new FlaskBlueprintYamlObject.
         :rtype: FlaskBlueprintYamlObject
         '''
 
-        # Convert routes list to dict keyed by route ID.
-        return TransferObject.from_model(
-            FlaskBlueprintYamlObject,
+        # Create from the model, converting nested routes list to dict.
+        return super().from_model(
             blueprint,
             routes={
-                route.id: TransferObject.from_model(FlaskRouteYamlObject, route)
+                route.id: FlaskRouteYamlObject.from_model(route)
                 for route in blueprint.routes
             },
-            **kwargs,
+            **overrides,
         )

--- a/tiferet_flask/mappers/tests/test_flask.py
+++ b/tiferet_flask/mappers/tests/test_flask.py
@@ -5,7 +5,7 @@ from typing import List
 
 # ** infra
 import pytest
-from tiferet import DomainObject, TransferObject
+from tiferet import TiferetError
 
 # ** app
 from ..flask import (
@@ -28,11 +28,12 @@ def flask_route_aggregate() -> FlaskRouteAggregate:
     :rtype: FlaskRouteAggregate
     '''
 
-    return FlaskRouteAggregate.new(
+    return FlaskRouteAggregate(
         id='sample_route',
+        endpoint='sample_blueprint.sample_route',
         rule='/sample',
         methods=['GET', 'POST'],
-        status_code=200
+        status_code=200,
     )
 
 # ** fixture: flask_blueprint_aggregate
@@ -47,9 +48,9 @@ def flask_blueprint_aggregate(flask_route_aggregate: FlaskRouteAggregate) -> Fla
     :rtype: FlaskBlueprintAggregate
     '''
 
-    return FlaskBlueprintAggregate.new(
+    return FlaskBlueprintAggregate(
         name='sample_blueprint',
-        routes=[flask_route_aggregate]
+        routes=[flask_route_aggregate],
     )
 
 # ** fixture: flask_blueprint_yaml_data_raw
@@ -86,9 +87,8 @@ def flask_blueprint_yaml_data(flask_blueprint_yaml_data_raw: dict) -> List[Flask
     '''
 
     return [
-        FlaskBlueprintYamlObject.from_data(
-            name=name,
-            **blueprint
+        FlaskBlueprintYamlObject.model_validate(
+            dict(name=name, **blueprint)
         ) for name, blueprint in flask_blueprint_yaml_data_raw.items()
     ]
 
@@ -101,9 +101,28 @@ def test_flask_route_aggregate_creation(flask_route_aggregate: FlaskRouteAggrega
     '''
 
     assert flask_route_aggregate.id == 'sample_route'
+    assert flask_route_aggregate.endpoint == 'sample_blueprint.sample_route'
     assert flask_route_aggregate.rule == '/sample'
     assert flask_route_aggregate.methods == ['GET', 'POST']
     assert flask_route_aggregate.status_code == 200
+
+# ** test: flask_route_aggregate_set_attribute
+def test_flask_route_aggregate_set_attribute(flask_route_aggregate: FlaskRouteAggregate):
+    '''
+    Test valid set_attribute on FlaskRouteAggregate.
+    '''
+
+    flask_route_aggregate.set_attribute('rule', '/updated')
+    assert flask_route_aggregate.rule == '/updated'
+
+# ** test: flask_route_aggregate_set_attribute_invalid
+def test_flask_route_aggregate_set_attribute_invalid(flask_route_aggregate: FlaskRouteAggregate):
+    '''
+    Test that set_attribute raises error for an invalid attribute.
+    '''
+
+    with pytest.raises(TiferetError):
+        flask_route_aggregate.set_attribute('invalid_attr', 'value')
 
 # ** test: flask_blueprint_aggregate_creation
 def test_flask_blueprint_aggregate_creation(flask_blueprint_aggregate: FlaskBlueprintAggregate):
@@ -120,18 +139,17 @@ def test_flask_blueprint_aggregate_add_route(flask_blueprint_aggregate: FlaskBlu
     Test adding a route to a FlaskBlueprintAggregate.
     '''
 
-    # Create a new route aggregate.
-    new_route = FlaskRouteAggregate.new(
-        id='new_route',
+    # Add a route using the new signature.
+    route = flask_blueprint_aggregate.add_route(
+        endpoint='new_route',
         rule='/new',
-        methods=['DELETE']
+        methods=['DELETE'],
     )
 
-    # Add the route.
-    flask_blueprint_aggregate.add_route(new_route)
-
-    # Assert the route was added.
+    # Assert the route was added with correct endpoint.
     assert len(flask_blueprint_aggregate.routes) == 2
+    assert route.id == 'new_route'
+    assert route.endpoint == 'sample_blueprint.new_route'
     assert flask_blueprint_aggregate.routes[1].id == 'new_route'
 
 # ** test: flask_blueprint_aggregate_remove_route
@@ -159,7 +177,6 @@ def test_flask_blueprint_yaml_data_creation(flask_blueprint_yaml_data: List[Flas
     assert len(blueprint.routes) == 1
 
     route = blueprint.routes['sample_route']
-    assert route.id == 'sample_route'
     assert route.rule == '/sample'
     assert route.methods == ['GET', 'POST']
 
@@ -180,6 +197,7 @@ def test_flask_blueprint_yaml_data_map(flask_blueprint_yaml_data: List[FlaskBlue
     route = aggregate.routes[0]
     assert isinstance(route, FlaskRouteAggregate)
     assert route.id == 'sample_route'
+    assert route.endpoint == 'sample_blueprint.sample_route'
     assert route.rule == '/sample'
     assert route.methods == ['GET', 'POST']
 
@@ -196,3 +214,24 @@ def test_flask_blueprint_yaml_object_from_model(flask_blueprint_aggregate: Flask
     assert yaml_obj.name == 'sample_blueprint'
     assert 'sample_route' in yaml_obj.routes
     assert yaml_obj.routes['sample_route'].rule == '/sample'
+
+# ** test: flask_blueprint_round_trip
+def test_flask_blueprint_round_trip(flask_blueprint_aggregate: FlaskBlueprintAggregate):
+    '''
+    Test full round-trip: aggregate → YAML object → aggregate.
+    '''
+
+    # Convert aggregate to YAML object.
+    yaml_obj = FlaskBlueprintYamlObject.from_model(flask_blueprint_aggregate)
+
+    # Map back to aggregate.
+    result = yaml_obj.map()
+
+    # Assert the round-trip preserves data.
+    assert isinstance(result, FlaskBlueprintAggregate)
+    assert result.name == flask_blueprint_aggregate.name
+    assert len(result.routes) == len(flask_blueprint_aggregate.routes)
+    assert result.routes[0].id == flask_blueprint_aggregate.routes[0].id
+    assert result.routes[0].endpoint == flask_blueprint_aggregate.routes[0].endpoint
+    assert result.routes[0].rule == flask_blueprint_aggregate.routes[0].rule
+    assert result.routes[0].methods == flask_blueprint_aggregate.routes[0].methods


### PR DESCRIPTION
## Summary
Migrate all mapper classes from Schematics-based patterns to Pydantic v2, aligning with `tiferet>=2.0.0b1` and tiferet-fast patterns.

### Changes
- **`mappers/flask.py`** — Replaced Schematics imports with Pydantic v2. Removed `new()` static factories from both aggregates. `FlaskRouteAggregate` is now a passthrough. `FlaskBlueprintAggregate.add_route` constructs routes with `endpoint` field. Replaced `class Options` with `_ROLES` ClassVar on both transfer objects. Converted `from_model` to `@classmethod`. Replaced `from_data` with `model_validate`.
- **`mappers/__init__.py`** — Added module-level docstring header.
- **`mappers/tests/test_flask.py`** — Replaced `.new()` and `.from_data()` with direct constructors and `model_validate()`. Added `set_attribute` tests (valid + invalid), endpoint assertions, and a full round-trip test. 10 tests pass.

Closes #30

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>