### PR TITLE
Interfaces – Service Contract Update (#31)

### DIFF
--- a/tiferet_flask/interfaces/__init__.py
+++ b/tiferet_flask/interfaces/__init__.py
@@ -1,3 +1,5 @@
+"""Flask service interfaces."""
+
 # *** imports
 
 # ** app

--- a/tiferet_flask/interfaces/flask.py
+++ b/tiferet_flask/interfaces/flask.py
@@ -1,3 +1,5 @@
+"""Flask service interfaces."""
+
 # *** imports
 
 # ** core
@@ -5,13 +7,10 @@ from abc import abstractmethod
 from typing import List
 
 # ** infra
-from tiferet.interfaces.settings import Service
+from tiferet.interfaces import Service
 
 # ** app
-from ..mappers import (
-    FlaskBlueprintAggregate,
-    FlaskRouteAggregate
-)
+from ..domain import FlaskBlueprint, FlaskRoute
 
 # *** interfaces
 
@@ -21,33 +20,20 @@ class FlaskApiService(Service):
     Service interface for managing Flask API configuration.
     '''
 
-    # * method: exists
-    @abstractmethod
-    def exists(self, blueprint_name: str) -> bool:
-        '''
-        Check if a blueprint exists by name.
-
-        :param blueprint_name: The blueprint name.
-        :type blueprint_name: str
-        :return: True if the blueprint exists, otherwise False.
-        :rtype: bool
-        '''
-        raise NotImplementedError('exists method is required for FlaskApiService.')
-
     # * method: get_blueprints
     @abstractmethod
-    def get_blueprints(self) -> List[FlaskBlueprintAggregate]:
+    def get_blueprints(self) -> List[FlaskBlueprint]:
         '''
         Retrieve all Flask blueprints.
 
-        :return: A list of Flask blueprint aggregates.
-        :rtype: List[FlaskBlueprintAggregate]
+        :return: A list of Flask blueprints.
+        :rtype: List[FlaskBlueprint]
         '''
-        raise NotImplementedError('get_blueprints method is required for FlaskApiService.')
+        raise NotImplementedError()
 
     # * method: get_route
     @abstractmethod
-    def get_route(self, route_id: str, blueprint_name: str = None) -> FlaskRouteAggregate | None:
+    def get_route(self, route_id: str, blueprint_name: str = None) -> FlaskRoute:
         '''
         Retrieve a specific Flask route by its ID and optional blueprint name.
 
@@ -55,10 +41,10 @@ class FlaskApiService(Service):
         :type route_id: str
         :param blueprint_name: The blueprint name (optional).
         :type blueprint_name: str
-        :return: The Flask route aggregate, or None if not found.
-        :rtype: FlaskRouteAggregate | None
+        :return: The Flask route.
+        :rtype: FlaskRoute
         '''
-        raise NotImplementedError('get_route method is required for FlaskApiService.')
+        raise NotImplementedError()
 
     # * method: get_status_code
     @abstractmethod
@@ -71,30 +57,4 @@ class FlaskApiService(Service):
         :return: The corresponding HTTP status code.
         :rtype: int
         '''
-        raise NotImplementedError('get_status_code method is required for FlaskApiService.')
-
-    # * method: save
-    @abstractmethod
-    def save(self, blueprint: FlaskBlueprintAggregate) -> None:
-        '''
-        Save or update a Flask blueprint configuration.
-
-        :param blueprint: The blueprint aggregate to save.
-        :type blueprint: FlaskBlueprintAggregate
-        :return: None
-        :rtype: None
-        '''
-        raise NotImplementedError('save method is required for FlaskApiService.')
-
-    # * method: delete
-    @abstractmethod
-    def delete(self, blueprint_name: str) -> None:
-        '''
-        Delete a Flask blueprint by name. This operation should be idempotent.
-
-        :param blueprint_name: The blueprint name.
-        :type blueprint_name: str
-        :return: None
-        :rtype: None
-        '''
-        raise NotImplementedError('delete method is required for FlaskApiService.')
+        raise NotImplementedError()


### PR DESCRIPTION
## Summary
Update `FlaskApiService` to return domain objects (`FlaskBlueprint`, `FlaskRoute`) instead of aggregates, removing the circular dependency on the `mappers` module.

### Changes
- **`interfaces/flask.py`** — Return types changed from `FlaskBlueprintAggregate`/`FlaskRouteAggregate` to `FlaskBlueprint`/`FlaskRoute`. Removed `exists`, `save`, `delete` methods. Import changed from `tiferet.interfaces.settings` to `tiferet.interfaces`. Added module-level docstring.
- **`interfaces/__init__.py`** — Added module-level docstring header.

Closes #31

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>