### PR TITLE
Repository – YamlLoader Migration (#33)

### DIFF
--- a/tiferet_flask/repos/__init__.py
+++ b/tiferet_flask/repos/__init__.py
@@ -1,3 +1,5 @@
+"""Flask repositories."""
+
 # *** imports
 
 # ** app

--- a/tiferet_flask/repos/flask.py
+++ b/tiferet_flask/repos/flask.py
@@ -1,22 +1,17 @@
+"""Flask YAML repository."""
+
 # *** imports
 
 # ** core
 from typing import List
 
 # ** infra
-from tiferet import (
-    Yaml,
-    TransferObject
-)
+from tiferet.utils import YamlLoader
 
 # ** app
+from ..domain import FlaskBlueprint, FlaskRoute
 from ..interfaces import FlaskApiService
-from ..mappers import (
-    FlaskBlueprintAggregate,
-    FlaskRouteAggregate,
-    FlaskBlueprintYamlObject,
-    FlaskRouteYamlObject
-)
+from ..mappers import FlaskBlueprintYamlObject
 
 # *** repos
 
@@ -26,81 +21,50 @@ class FlaskYamlRepository(FlaskApiService):
     A YAML-backed repository for Flask API configuration.
     '''
 
-    # * attribute: yaml_file
-    yaml_file: str
+    # * attribute: flask_yaml_file
+    flask_yaml_file: str
 
     # * attribute: encoding
     encoding: str
 
-    # * attribute: default_role
-    default_role: str
-
     # * init
-    def __init__(self, flask_config_file: str, encoding: str = 'utf-8') -> None:
+    def __init__(self, flask_yaml_file: str, encoding: str = 'utf-8'):
         '''
         Initialize the Flask YAML repository.
 
-        :param flask_config_file: The path to the Flask configuration YAML file.
-        :type flask_config_file: str
-        :param encoding: The file encoding (default is 'utf-8').
+        :param flask_yaml_file: The path to the Flask configuration YAML file.
+        :type flask_yaml_file: str
+        :param encoding: The file encoding.
         :type encoding: str
         '''
 
-        # Set the repository attributes.
-        self.yaml_file = flask_config_file
+        # Set the YAML file path and encoding.
+        self.flask_yaml_file = flask_yaml_file
         self.encoding = encoding
-        self.default_role = 'to_data'
-
-    # * method: exists
-    def exists(self, blueprint_name: str) -> bool:
-        '''
-        Check if a blueprint exists by name.
-
-        :param blueprint_name: The blueprint name.
-        :type blueprint_name: str
-        :return: True if the blueprint exists, otherwise False.
-        :rtype: bool
-        '''
-
-        # Load the blueprints mapping from the configuration file.
-        blueprints_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
-            start_node=lambda data: data.get('flask', {}).get('blueprints', {})
-        )
-
-        # Return whether the blueprint name exists in the mapping.
-        return blueprint_name in blueprints_data
 
     # * method: get_blueprints
-    def get_blueprints(self) -> List[FlaskBlueprintAggregate]:
+    def get_blueprints(self) -> List[FlaskBlueprint]:
         '''
         Retrieve all Flask blueprints.
 
-        :return: A list of Flask blueprint aggregates.
-        :rtype: List[FlaskBlueprintAggregate]
+        :return: A list of Flask blueprints.
+        :rtype: List[FlaskBlueprint]
         '''
 
-        # Load the blueprints section from the configuration file.
-        blueprints_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
-            start_node=lambda data: data.get('flask', {}).get('blueprints', {})
+        # Load the blueprints section from the YAML file.
+        loader = YamlLoader(path=self.flask_yaml_file, mode='r', encoding=self.encoding)
+        data = loader.load(
+            start_node=lambda d: d.get('flask', {}).get('blueprints', {}),
         )
 
-        # Map each blueprint entry to a FlaskBlueprintAggregate.
+        # Map each blueprint entry to a domain object via FlaskBlueprintYamlObject.
         return [
-            FlaskBlueprintYamlObject.from_data(
-                name=name,
-                **blueprint_data
-            ).map()
-            for name, blueprint_data in blueprints_data.items()
+            FlaskBlueprintYamlObject.model_validate(dict(name=name, **bp_data)).map()
+            for name, bp_data in data.items()
         ]
 
     # * method: get_route
-    def get_route(self, route_id: str, blueprint_name: str = None) -> FlaskRouteAggregate | None:
+    def get_route(self, route_id: str, blueprint_name: str = None) -> FlaskRoute:
         '''
         Retrieve a specific Flask route by its ID and optional blueprint name.
 
@@ -108,8 +72,8 @@ class FlaskYamlRepository(FlaskApiService):
         :type route_id: str
         :param blueprint_name: The blueprint name (optional).
         :type blueprint_name: str
-        :return: The Flask route aggregate, or None if not found.
-        :rtype: FlaskRouteAggregate | None
+        :return: The corresponding FlaskRoute instance, or None if not found.
+        :rtype: FlaskRoute
         '''
 
         # Load all blueprints.
@@ -119,13 +83,11 @@ class FlaskYamlRepository(FlaskApiService):
         for blueprint in blueprints:
             if blueprint_name and blueprint.name != blueprint_name:
                 continue
-
-            # Search for the route within the blueprint.
             for route in blueprint.routes:
                 if route.id == route_id:
                     return route
 
-        # If not found, return None.
+        # Return None if not found.
         return None
 
     # * method: get_status_code
@@ -139,70 +101,11 @@ class FlaskYamlRepository(FlaskApiService):
         :rtype: int
         '''
 
-        # Load the error code mapping from the configuration file.
-        errors_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load(
-            start_node=lambda data: data.get('flask', {}).get('errors', {})
+        # Load the errors section from the YAML file.
+        loader = YamlLoader(path=self.flask_yaml_file, mode='r', encoding=self.encoding)
+        data = loader.load(
+            start_node=lambda d: d.get('flask', {}).get('errors', {}),
         )
 
         # Return the status code if found, otherwise default to 500.
-        return errors_data.get(error_code, 500)
-
-    # * method: save
-    def save(self, blueprint: FlaskBlueprintAggregate) -> None:
-        '''
-        Save or update a Flask blueprint configuration.
-
-        :param blueprint: The blueprint aggregate to save.
-        :type blueprint: FlaskBlueprintAggregate
-        :return: None
-        :rtype: None
-        '''
-
-        # Convert the blueprint aggregate to YAML transfer object.
-        blueprint_data = FlaskBlueprintYamlObject.from_model(blueprint)
-
-        # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
-
-        # Update or insert the blueprint entry.
-        full_data.setdefault('flask', {}).setdefault('blueprints', {})[blueprint.name] = blueprint_data.to_primitive(self.default_role)
-
-        # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
-
-    # * method: delete
-    def delete(self, blueprint_name: str) -> None:
-        '''
-        Delete a Flask blueprint by name. This operation is idempotent.
-
-        :param blueprint_name: The blueprint name.
-        :type blueprint_name: str
-        :return: None
-        :rtype: None
-        '''
-
-        # Load the full configuration file.
-        full_data = Yaml(
-            self.yaml_file,
-            encoding=self.encoding,
-        ).load()
-
-        # Remove the blueprint entry if it exists (idempotent).
-        full_data.get('flask', {}).get('blueprints', {}).pop(blueprint_name, None)
-
-        # Persist the updated configuration file.
-        Yaml(
-            self.yaml_file,
-            mode='w',
-            encoding=self.encoding,
-        ).save(data=full_data)
+        return data.get(error_code, 500)

--- a/tiferet_flask/repos/tests/test_flask.py
+++ b/tiferet_flask/repos/tests/test_flask.py
@@ -2,7 +2,6 @@
 
 # ** core
 from pathlib import Path
-from typing import List
 
 # ** infra
 import pytest
@@ -10,10 +9,7 @@ import yaml
 
 # ** app
 from ..flask import FlaskYamlRepository
-from ...mappers import (
-    FlaskBlueprintAggregate,
-    FlaskRouteAggregate
-)
+from ...domain import FlaskBlueprint, FlaskRoute
 
 # *** fixtures
 
@@ -80,25 +76,9 @@ def flask_repo(flask_yaml_file: str) -> FlaskYamlRepository:
     :rtype: FlaskYamlRepository
     '''
 
-    return FlaskYamlRepository(flask_config_file=flask_yaml_file)
+    return FlaskYamlRepository(flask_yaml_file=flask_yaml_file)
 
 # *** tests
-
-# ** test: flask_repo_exists_true
-def test_flask_repo_exists_true(flask_repo: FlaskYamlRepository):
-    '''
-    Test that exists returns True for a known blueprint.
-    '''
-
-    assert flask_repo.exists('sample_blueprint') is True
-
-# ** test: flask_repo_exists_false
-def test_flask_repo_exists_false(flask_repo: FlaskYamlRepository):
-    '''
-    Test that exists returns False for an unknown blueprint.
-    '''
-
-    assert flask_repo.exists('nonexistent_blueprint') is False
 
 # ** test: flask_repo_get_blueprints
 def test_flask_repo_get_blueprints(flask_repo: FlaskYamlRepository):
@@ -111,11 +91,12 @@ def test_flask_repo_get_blueprints(flask_repo: FlaskYamlRepository):
 
     # Assert structure and values.
     assert len(blueprints) == 1
-    assert isinstance(blueprints[0], FlaskBlueprintAggregate)
+    assert isinstance(blueprints[0], FlaskBlueprint)
     assert blueprints[0].name == 'sample_blueprint'
     assert blueprints[0].url_prefix == '/api'
     assert len(blueprints[0].routes) == 1
     assert blueprints[0].routes[0].id == 'sample_route'
+    assert blueprints[0].routes[0].endpoint == 'sample_blueprint.sample_route'
     assert blueprints[0].routes[0].rule == '/sample'
     assert blueprints[0].routes[0].methods == ['GET', 'POST']
     assert blueprints[0].routes[0].status_code == 269
@@ -129,12 +110,13 @@ def test_flask_repo_get_route(flask_repo: FlaskYamlRepository):
     # Retrieve route by ID and blueprint name.
     route = flask_repo.get_route(
         route_id='sample_route',
-        blueprint_name='sample_blueprint'
+        blueprint_name='sample_blueprint',
     )
 
     # Assert route values.
-    assert isinstance(route, FlaskRouteAggregate)
+    assert isinstance(route, FlaskRoute)
     assert route.id == 'sample_route'
+    assert route.endpoint == 'sample_blueprint.sample_route'
     assert route.rule == '/sample'
     assert route.methods == ['GET', 'POST']
     assert route.status_code == 269
@@ -178,64 +160,3 @@ def test_flask_repo_get_status_code_default(flask_repo: FlaskYamlRepository):
 
     status_code = flask_repo.get_status_code('UNKNOWN_ERROR')
     assert status_code == 500
-
-# ** test: flask_repo_save
-def test_flask_repo_save(flask_repo: FlaskYamlRepository):
-    '''
-    Test saving a new blueprint to the YAML configuration.
-    '''
-
-    # Create a new blueprint aggregate.
-    new_blueprint = FlaskBlueprintAggregate.new(
-        name='new_blueprint',
-        url_prefix='/new',
-        routes=[
-            FlaskRouteAggregate.new(
-                id='new_route',
-                rule='/new-endpoint',
-                methods=['PUT'],
-                status_code=201
-            )
-        ]
-    )
-
-    # Save the blueprint.
-    flask_repo.save(new_blueprint)
-
-    # Verify it was persisted by reading it back.
-    assert flask_repo.exists('new_blueprint') is True
-    blueprints = flask_repo.get_blueprints()
-    assert len(blueprints) == 2
-
-    # Find the new blueprint.
-    saved = [b for b in blueprints if b.name == 'new_blueprint'][0]
-    assert saved.url_prefix == '/new'
-    assert len(saved.routes) == 1
-    assert saved.routes[0].id == 'new_route'
-
-# ** test: flask_repo_delete
-def test_flask_repo_delete(flask_repo: FlaskYamlRepository):
-    '''
-    Test deleting a blueprint from the YAML configuration.
-    '''
-
-    # Verify the blueprint exists.
-    assert flask_repo.exists('sample_blueprint') is True
-
-    # Delete the blueprint.
-    flask_repo.delete('sample_blueprint')
-
-    # Verify it was removed.
-    assert flask_repo.exists('sample_blueprint') is False
-
-# ** test: flask_repo_delete_idempotent
-def test_flask_repo_delete_idempotent(flask_repo: FlaskYamlRepository):
-    '''
-    Test that deleting a nonexistent blueprint does not raise an error.
-    '''
-
-    # Delete a nonexistent blueprint (should not raise).
-    flask_repo.delete('nonexistent_blueprint')
-
-    # Verify the existing blueprint is still present.
-    assert flask_repo.exists('sample_blueprint') is True


### PR DESCRIPTION
## Summary
Migrate `FlaskYamlRepository` from legacy `Yaml` shorthand to `YamlLoader` composition, aligning with tiferet-fast `FastYamlRepository`.

### Changes
- **`repos/flask.py`** — Replaced `Yaml(path).load()` with `YamlLoader(path=..., mode='r', encoding=...)`. Replaced `from_data()` with `model_validate()`. Renamed constructor param `flask_config_file` → `flask_yaml_file`. Removed `exists`, `save`, `delete` methods and `default_role` attribute. Added module-level docstring.
- **`repos/__init__.py`** — Added module-level docstring header.
- **`repos/tests/test_flask.py`** — Updated fixture to use `flask_yaml_file` param. Removed tests for `exists`, `save`, `delete`. Assert domain object types. Added `endpoint` assertion. 6 tests pass.

Closes #33

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>