### PR TITLE
Contexts – DomainEvent Injection & Request Update (#34)

### DIFF
--- a/tiferet_flask/contexts/__init__.py
+++ b/tiferet_flask/contexts/__init__.py
@@ -1,9 +1,7 @@
-# *** export
+"""Flask contexts."""
+
+# *** exports
 
 # ** app
-from .request import (
-    RequestContext
-)
-from .flask import (
-    FlaskApiContext
-)
+from .request import FlaskRequestContext
+from .flask import FlaskApiContext

--- a/tiferet_flask/contexts/flask.py
+++ b/tiferet_flask/contexts/flask.py
@@ -1,23 +1,23 @@
+"""Flask API context."""
+
 # *** imports
 
 # ** core
 from typing import Any, Callable
 
 # ** infra
-from flask import Flask, Blueprint
-from tiferet.contexts.app import (
+from tiferet import TiferetError
+from tiferet.assets.exceptions import TiferetAPIError
+from tiferet.contexts import (
     AppInterfaceContext,
-    RequestContext,
-    TiferetError
+    FeatureContext,
+    ErrorContext,
+    LoggingContext,
 )
-from tiferet import TiferetAPIError
-from tiferet.contexts.error import ErrorContext
-from tiferet.contexts.feature import FeatureContext
-from tiferet.contexts.logging import LoggingContext
+from tiferet.events import DomainEvent
 
 # ** app
 from .request import FlaskRequestContext
-from ..domain import FlaskBlueprint
 
 # *** contexts
 
@@ -27,12 +27,6 @@ class FlaskApiContext(AppInterfaceContext):
     A context for managing Flask API interactions within the Tiferet framework.
     '''
 
-    # * attribute: flask_app
-    flask_app: Flask
-
-    # * attribute: get_blueprints_handler
-    get_blueprints_handler: Callable
-
     # * attribute: get_route_handler
     get_route_handler: Callable
 
@@ -41,14 +35,13 @@ class FlaskApiContext(AppInterfaceContext):
 
     # * init
     def __init__(self,
-        interface_id: str,
-        features: FeatureContext,
-        errors: ErrorContext,
-        logging: LoggingContext,
-        get_blueprints_handler: Callable,
-        get_route_handler: Callable,
-        get_status_code_handler: Callable
-    ):
+            interface_id: str,
+            features: FeatureContext,
+            errors: ErrorContext,
+            logging: LoggingContext,
+            get_route_evt: DomainEvent,
+            get_status_code_evt: DomainEvent,
+        ):
         '''
         Initialize the Flask API context.
 
@@ -60,21 +53,18 @@ class FlaskApiContext(AppInterfaceContext):
         :type errors: ErrorContext
         :param logging: The logging context.
         :type logging: LoggingContext
-        :param get_blueprints_handler: Callable to retrieve all Flask blueprints.
-        :type get_blueprints_handler: Callable
-        :param get_route_handler: Callable to retrieve a Flask route by endpoint.
-        :type get_route_handler: Callable
-        :param get_status_code_handler: Callable to retrieve HTTP status code for an error code.
-        :type get_status_code_handler: Callable
+        :param get_route_evt: The domain event for retrieving a route.
+        :type get_route_evt: DomainEvent
+        :param get_status_code_evt: The domain event for retrieving a status code.
+        :type get_status_code_evt: DomainEvent
         '''
 
         # Call the parent constructor.
         super().__init__(interface_id, features, errors, logging)
 
-        # Set the handler callables.
-        self.get_blueprints_handler = get_blueprints_handler
-        self.get_route_handler = get_route_handler
-        self.get_status_code_handler = get_status_code_handler
+        # Set the domain event handlers.
+        self.get_route_handler = get_route_evt.execute
+        self.get_status_code_handler = get_status_code_evt.execute
 
     # * method: parse_request
     def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> FlaskRequestContext:
@@ -101,114 +91,49 @@ class FlaskApiContext(AppInterfaceContext):
         )
 
     # * method: handle_error
-    def handle_error(self, error: Exception) -> Any:
+    def handle_error(self, error: Exception, **kwargs) -> Any:
         '''
-        Handle the error and return the response with status code.
+        Handle the error and raise TiferetAPIError with status_code.
 
         :param error: The error to handle.
         :type error: Exception
-        :return: The error response tuple (response, status_code).
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The error response.
         :rtype: Any
         '''
 
-        # Determine the status code before formatting.
-        if not isinstance(error, TiferetError):
-            status_code = 500
-        else:
+        # Get the status code via event if it's a TiferetError.
+        if isinstance(error, TiferetError):
             status_code = self.get_status_code_handler(error_code=error.error_code)
+        else:
+            status_code = 500
 
-        # Format the error via the parent, catching the TiferetAPIError it raises.
+        # Delegate formatting to parent (which raises TiferetAPIError).
         try:
-            super().handle_error(error)
+            return super().handle_error(error, **kwargs)
         except TiferetAPIError as api_error:
-            return dict(
-                error_code=api_error.error_code,
-                name=api_error.name,
-                message=api_error.message,
-            ), status_code
+            api_error.status_code = status_code
+            raise
 
     # * method: handle_response
-    def handle_response(self, request: RequestContext) -> Any:
+    def handle_response(self, request: FlaskRequestContext, **kwargs) -> Any:
         '''
         Handle the response from the request context.
 
         :param request: The request context.
-        :type request: RequestContext
-        :return: The response tuple (response, status_code).
+        :type request: FlaskRequestContext
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The response and status code.
         :rtype: Any
         '''
 
         # Handle the response from the request context.
-        response = super().handle_response(request)
+        response = super().handle_response(request, **kwargs)
 
-        # Retrieve the route by the request feature id via the handler callable.
+        # Retrieve the route by the request feature id.
         route = self.get_route_handler(endpoint=request.feature_id)
 
-        # Return the result as JSON with the specified status code.
-        return response, route.status_code
-
-    # * method: build_blueprint
-    def build_blueprint(self, flask_blueprint: FlaskBlueprint, view_func: Callable, **kwargs) -> Blueprint:
-        '''
-        Assembles a Flask blueprint from the given FlaskBlueprint domain object.
-
-        :param flask_blueprint: The FlaskBlueprint domain object.
-        :type flask_blueprint: FlaskBlueprint
-        :param view_func: The view function to handle requests.
-        :type view_func: Callable
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The created Flask blueprint.
-        :rtype: Blueprint
-        '''
-
-        # Create the blueprint.
-        blueprint = Blueprint(
-            flask_blueprint.name,
-            __name__,
-            url_prefix=flask_blueprint.url_prefix
-        )
-
-        # Add the url rules.
-        for route in flask_blueprint.routes:
-            blueprint.add_url_rule(
-                route.rule,
-                route.id,
-                methods=route.methods,
-                view_func=view_func,
-            )
-
-        # Return the created blueprint.
-        return blueprint
-
-    # * method: build_flask_app
-    def build_flask_app(self, view_func: Callable, **kwargs) -> Flask:
-        '''
-        Build and return a Flask application instance.
-
-        :param view_func: The view function to handle requests.
-        :type view_func: Callable
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A Flask application instance.
-        :rtype: Flask
-        '''
-
-        # Import CORS here to avoid circular import issues.
-        from flask_cors import CORS
-
-        # Create the Flask application.
-        # Enable CORS for the Flask application.
-        flask_app = Flask(__name__)
-        CORS(flask_app)
-
-        # Load the Flask blueprints via the handler callable.
-        blueprints = self.get_blueprints_handler()
-
-        # Create and register the blueprints.
-        for bp in blueprints:
-            blueprint = self.build_blueprint(bp, view_func=view_func, **kwargs)
-            flask_app.register_blueprint(blueprint)
-
-        # Set the flask_app attribute.
-        self.flask_app = flask_app
+        # Return the result with the specified status code.
+        return response, route.status_code if route else 200

--- a/tiferet_flask/contexts/request.py
+++ b/tiferet_flask/contexts/request.py
@@ -1,18 +1,20 @@
+"""Flask request context."""
+
 # *** imports
 
 # ** core
 from typing import Any
 
 # ** infra
+from pydantic import BaseModel
 from tiferet.contexts.request import RequestContext
-from tiferet import DomainObject
 
 # *** contexts
 
 # ** context: flask_request_context
 class FlaskRequestContext(RequestContext):
     '''
-    A request context for Flask API interactions.
+    A context for handling Flask API request data and responses.
     '''
 
     # * method: handle_response
@@ -37,30 +39,32 @@ class FlaskRequestContext(RequestContext):
 
         :param result: The result to set.
         :type result: Any
-        :param data_key: The key in the request data to set the result to. If provided, delegates to the parent method.
+        :param data_key: The key in the request data to set the result to.
+            If provided, the raw result is stored for downstream commands.
+            If None, the result is serialized for the final response.
         :type data_key: str
         '''
 
-        # If a data key is provided, delegate to the parent method.
+        # If a data key is provided, delegate to the parent to store the raw result.
         if data_key:
-            super().set_result(result, data_key)
+            super().set_result(result, data_key=data_key)
             return
 
         # If the response is None, return an empty response.
         if result is None:
             self.result = ''
 
-        # Convert the response to a dictionary if it's a DomainObject.
-        elif isinstance(result, DomainObject):
-            self.result = result.to_primitive()
+        # Convert the response to a dictionary if it's a BaseModel.
+        elif isinstance(result, BaseModel):
+            self.result = result.model_dump()
 
-        # If the response is a list containing domain objects, convert each to a dictionary.
-        elif isinstance(result, list) and all(isinstance(item, DomainObject) for item in result):
-            self.result = [item.to_primitive() for item in result]
+        # If the response is a list containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, list) and all(isinstance(item, BaseModel) for item in result):
+            self.result = [item.model_dump() for item in result]
 
-        # If the response is a dict containing domain objects, convert each to a dictionary.
-        elif isinstance(result, dict) and all(isinstance(value, DomainObject) for value in result.values()):
-            self.result = {key: value.to_primitive() for key, value in result.items()}
+        # If the response is a dict containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, dict) and all(isinstance(value, BaseModel) for value in result.values()):
+            self.result = {key: value.model_dump() for key, value in result.items()}
 
         # Otherwise, set the result directly.
         else:

--- a/tiferet_flask/contexts/tests/test_flask.py
+++ b/tiferet_flask/contexts/tests/test_flask.py
@@ -3,59 +3,38 @@
 # ** infra
 import pytest
 from unittest import mock
-from flask import Flask, Blueprint
-from tiferet import DomainObject
+from tiferet.assets.exceptions import TiferetAPIError
 from tiferet.contexts.error import ErrorContext
 from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
 from tiferet import TiferetError
+from tiferet.events import DomainEvent
 
 # ** app
 from ..flask import FlaskApiContext
 from ..request import FlaskRequestContext
-from ...domain import (
-    FlaskBlueprint,
-    FlaskRoute
-)
-from ...mappers import (
-    FlaskBlueprintAggregate,
-    FlaskRouteAggregate
-)
+from ...domain import FlaskRoute
 
 # *** fixtures
 
-# ** fixture: sample_route_aggregate
+# ** fixture: sample_route
 @pytest.fixture
-def sample_route_aggregate() -> FlaskRouteAggregate:
+def sample_route() -> FlaskRoute:
     '''
-    Fixture to provide a sample FlaskRouteAggregate.
+    Fixture to provide a sample FlaskRoute.
     '''
 
-    return FlaskRouteAggregate.new(
+    return FlaskRoute(
         id='sample_route',
+        endpoint='sample_blueprint.sample_route',
         rule='/sample',
         methods=['GET', 'POST'],
-        status_code=269
-    )
-
-# ** fixture: sample_blueprint_aggregate
-@pytest.fixture
-def sample_blueprint_aggregate(sample_route_aggregate: FlaskRouteAggregate) -> FlaskBlueprintAggregate:
-    '''
-    Fixture to provide a sample FlaskBlueprintAggregate.
-    '''
-
-    return FlaskBlueprintAggregate.new(
-        name='sample_blueprint',
-        routes=[sample_route_aggregate]
+        status_code=269,
     )
 
 # ** fixture: flask_api_context
 @pytest.fixture
-def flask_api_context(
-    sample_blueprint_aggregate: FlaskBlueprintAggregate,
-    sample_route_aggregate: FlaskRouteAggregate
-) -> FlaskApiContext:
+def flask_api_context(sample_route: FlaskRoute) -> FlaskApiContext:
     '''
     Fixture to provide a FlaskApiContext instance for testing.
     '''
@@ -66,10 +45,11 @@ def flask_api_context(
     mock_errors.handle_error.return_value = {'error_code': 'APP_ERROR', 'name': 'Application Error', 'message': 'An error occurred.'}
     mock_logging = mock.Mock(spec=LoggingContext)
 
-    # Create mock callable handlers.
-    mock_get_blueprints = mock.Mock(return_value=[sample_blueprint_aggregate])
-    mock_get_route = mock.Mock(return_value=sample_route_aggregate)
-    mock_get_status_code = mock.Mock(return_value=420)
+    # Create mock DomainEvent instances.
+    mock_get_route_evt = mock.Mock(spec=DomainEvent)
+    mock_get_route_evt.execute = mock.Mock(return_value=sample_route)
+    mock_get_status_code_evt = mock.Mock(spec=DomainEvent)
+    mock_get_status_code_evt.execute = mock.Mock(return_value=420)
 
     # Create and return the FlaskApiContext instance.
     return FlaskApiContext(
@@ -77,9 +57,8 @@ def flask_api_context(
         features=mock_features,
         errors=mock_errors,
         logging=mock_logging,
-        get_blueprints_handler=mock_get_blueprints,
-        get_route_handler=mock_get_route,
-        get_status_code_handler=mock_get_status_code,
+        get_route_evt=mock_get_route_evt,
+        get_status_code_evt=mock_get_status_code_evt,
     )
 
 # *** tests
@@ -88,9 +67,6 @@ def flask_api_context(
 def test_flask_api_parse_request(flask_api_context: FlaskApiContext):
     '''
     Test the parse_request method of FlaskApiContext.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
     '''
 
     # Sample headers and data.
@@ -101,7 +77,7 @@ def test_flask_api_parse_request(flask_api_context: FlaskApiContext):
     request_context = flask_api_context.parse_request(
         headers=sample_headers,
         data=sample_data,
-        feature_id='test_feature'
+        feature_id='test_feature',
     )
 
     # Assert that the returned object is a FlaskRequestContext instance.
@@ -114,51 +90,33 @@ def test_flask_api_parse_request(flask_api_context: FlaskApiContext):
 def test_flask_api_context_handle_error(flask_api_context: FlaskApiContext):
     '''
     Test the handle_error method with a non-TiferetError exception.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
     '''
 
     # Create a sample exception.
     sample_exception = Exception('Sample error')
 
-    # Handle the error.
-    response, status_code = flask_api_context.handle_error(sample_exception)
+    # Handle the error and expect TiferetAPIError.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        flask_api_context.handle_error(sample_exception)
 
-    # Assert that the status code is 500 for generic errors.
-    assert isinstance(response, dict)
-    assert response['error_code'] == 'APP_ERROR'
-    assert status_code == 500
+    # Assert the status code is 500 for generic errors.
+    assert exc_info.value.status_code == 500
 
 # ** test: flask_api_context_handle_tiferet_error
 def test_flask_api_context_handle_tiferet_error(flask_api_context: FlaskApiContext):
     '''
     Test the handle_error method with a TiferetError.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
     '''
 
     # Create a sample TiferetError.
     sample_tiferet_error = TiferetError('TEST_ERROR', 'A test Tiferet error occurred.')
 
-    # Mock the error handler to return a specific response.
-    flask_api_context.errors.handle_error.return_value = {
-        'error_code': 'TEST_ERROR',
-        'name': 'Test Error',
-        'message': 'A test Tiferet error occurred.'
-    }
+    # Handle the error and expect TiferetAPIError.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        flask_api_context.handle_error(sample_tiferet_error)
 
-    # Call the handle_error method.
-    response, status_code = flask_api_context.handle_error(sample_tiferet_error)
-
-    # Assert the response and status code.
-    assert response == {
-        'error_code': 'TEST_ERROR',
-        'name': 'Test Error',
-        'message': 'A test Tiferet error occurred.'
-    }
-    assert status_code == 420
+    # Assert the status code from the handler.
+    assert exc_info.value.status_code == 420
 
     # Assert the handler was called with the correct error code.
     flask_api_context.get_status_code_handler.assert_called_once_with(
@@ -169,16 +127,13 @@ def test_flask_api_context_handle_tiferet_error(flask_api_context: FlaskApiConte
 def test_flask_api_context_handle_response(flask_api_context: FlaskApiContext):
     '''
     Test the handle_response method.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
     '''
 
     # Create a new request context.
     request_context = flask_api_context.parse_request(
         headers={'Content-Type': 'application/json'},
         data={'key': 'value'},
-        feature_id='test_feature'
+        feature_id='test_feature',
     )
 
     # Set a sample result in the request context.
@@ -195,90 +150,3 @@ def test_flask_api_context_handle_response(flask_api_context: FlaskApiContext):
     flask_api_context.get_route_handler.assert_called_once_with(
         endpoint='test_feature'
     )
-
-# ** test: flask_api_context_build_blueprint
-def test_flask_api_context_build_blueprint(
-    flask_api_context: FlaskApiContext,
-    sample_blueprint_aggregate: FlaskBlueprintAggregate
-):
-    '''
-    Test the build_blueprint method.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
-    :param sample_blueprint_aggregate: A sample blueprint aggregate.
-    :type sample_blueprint_aggregate: FlaskBlueprintAggregate
-    '''
-
-    # Create a sample view function.
-    def sample_view_func():
-        return 'Sample Response'
-
-    # Build a sample blueprint.
-    blueprint = flask_api_context.build_blueprint(
-        flask_blueprint=sample_blueprint_aggregate,
-        view_func=sample_view_func
-    )
-
-    # Assert the blueprint was created correctly.
-    assert isinstance(blueprint, Blueprint)
-    assert blueprint.name == 'sample_blueprint'
-    assert blueprint.url_prefix is None
-
-# ** test: flask_api_context_build_blueprint_view_func_direct
-def test_flask_api_context_build_blueprint_view_func_direct(
-    flask_api_context: FlaskApiContext,
-    sample_blueprint_aggregate: FlaskBlueprintAggregate
-):
-    '''
-    Test that build_blueprint passes view_func directly to add_url_rule,
-    not wrapped in a lambda.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
-    :param sample_blueprint_aggregate: A sample blueprint aggregate.
-    :type sample_blueprint_aggregate: FlaskBlueprintAggregate
-    '''
-
-    # Create a sample view function.
-    def sample_view_func():
-        return 'Sample Response'
-
-    # Build a sample blueprint.
-    blueprint = flask_api_context.build_blueprint(
-        flask_blueprint=sample_blueprint_aggregate,
-        view_func=sample_view_func
-    )
-
-    # Get the registered view functions from the blueprint's deferred functions.
-    # Register the blueprint on a temporary Flask app to resolve deferred registrations.
-    app = Flask(__name__)
-    app.register_blueprint(blueprint)
-
-    # Assert the view function is the original function, not a lambda wrapper.
-    registered_view_func = app.view_functions.get('sample_blueprint.sample_route')
-    assert registered_view_func is sample_view_func
-
-# ** test: flask_api_context_build_flask_app
-def test_flask_api_context_build_flask_app(flask_api_context: FlaskApiContext):
-    '''
-    Test the build_flask_app method.
-
-    :param flask_api_context: A FlaskApiContext instance.
-    :type flask_api_context: FlaskApiContext
-    '''
-
-    # Create a sample view function.
-    def sample_view_func():
-        return 'Sample Response'
-
-    # Build a sample Flask app.
-    flask_api_context.build_flask_app(
-        view_func=sample_view_func
-    )
-
-    # Assert the Flask app was created.
-    assert isinstance(flask_api_context.flask_app, Flask)
-
-    # Assert the blueprints handler was called.
-    flask_api_context.get_blueprints_handler.assert_called_once()

--- a/tiferet_flask/contexts/tests/test_request.py
+++ b/tiferet_flask/contexts/tests/test_request.py
@@ -2,10 +2,7 @@
 
 # ** infra
 import pytest
-from tiferet import (
-    DomainObject,
-    StringType
-)
+from pydantic import BaseModel, Field
 
 # ** app
 from ..request import FlaskRequestContext
@@ -22,20 +19,16 @@ def request_context() -> FlaskRequestContext:
     :rtype: FlaskRequestContext
     '''
 
-    # Create a FlaskRequestContext.
-    request_context = FlaskRequestContext(
+    return FlaskRequestContext(
         data=dict(
             key='value',
-            another_key='another_value'
+            another_key='another_value',
         ),
         headers=dict(
             interface_id='test_interface',
         ),
-        feature_id='test_group.test_feature'
+        feature_id='test_group.test_feature',
     )
-
-    # Return the FlaskRequestContext.
-    return request_context
 
 # *** tests
 
@@ -43,77 +36,46 @@ def request_context() -> FlaskRequestContext:
 def test_request_context_handle_response_none(request_context: FlaskRequestContext):
     '''
     Test handling a response that is None.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
     '''
 
-    # Set the request context result to None.
     request_context.set_result(None)
-
-    # Handle a None response.
     response = request_context.handle_response()
-
-    # Check that the response is empty string.
     assert response == ''
 
 # ** test: request_context_handle_response_primitive
 def test_request_context_handle_response_primitive(request_context: FlaskRequestContext):
     '''
     Test handling a response that is a primitive type.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
     '''
 
-    # Set the request context result to a primitive type.
     request_context.set_result('test_string')
-
-    # Handle the response with a primitive type.
     response = request_context.handle_response()
-
-    # Check that the response is as expected.
     assert response == 'test_string'
 
 # ** test: request_context_handle_response_data
 def test_request_context_handle_response_data(request_context: FlaskRequestContext):
     '''
     Test handling a response with dict data.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
     '''
 
-    # Set the request context result to some data.
     request_context.result = {'key': 'value'}
-
-    # Handle the response with data.
     response = request_context.handle_response()
-
-    # Check that the response is as expected.
     assert response == {'key': 'value'}
 
-# ** test: request_context_handle_response_domain_object
-def test_request_context_handle_response_domain_object(request_context: FlaskRequestContext):
+# ** test: request_context_handle_response_base_model
+def test_request_context_handle_response_base_model(request_context: FlaskRequestContext):
     '''
-    Test handling a response that is a DomainObject.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
+    Test handling a response that is a BaseModel.
     '''
 
-    # Create a DomainObject to simulate a response.
-    class Data(DomainObject):
+    # Create a BaseModel subclass to simulate a response.
+    class Data(BaseModel):
+        key: str = Field(default='default_value')
 
-        key = StringType(
-            default='default_value',
-            required=True
-        )
+    # Set the request context result to a BaseModel.
+    request_context.set_result(Data(key='value'))
 
-    # Set the request context result to a DomainObject.
-    request_context.set_result(DomainObject.new(Data, key='value'))
-
-    # Handle the response with a DomainObject.
+    # Handle the response.
     response = request_context.handle_response()
 
     # Check that the response is a dict with expected data.
@@ -124,48 +86,33 @@ def test_request_context_handle_response_domain_object(request_context: FlaskReq
 def test_request_context_handle_response_list(request_context: FlaskRequestContext):
     '''
     Test handling a response that is a plain list.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
     '''
 
-    # Set the request context result to a list.
     request_context.result = ['item1', 'item2', 'item3']
-
-    # Handle the response with a list.
     response = request_context.handle_response()
-
-    # Check that the response is a list and has the expected items.
     assert isinstance(response, list)
     assert response == ['item1', 'item2', 'item3']
 
-# ** test: request_context_handle_response_domain_object_list
-def test_request_context_handle_response_domain_object_list(request_context: FlaskRequestContext):
+# ** test: request_context_handle_response_base_model_list
+def test_request_context_handle_response_base_model_list(request_context: FlaskRequestContext):
     '''
-    Test handling a response that is a list of DomainObjects.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
+    Test handling a response that is a list of BaseModel instances.
     '''
 
-    # Create a DomainObject to simulate a response.
-    class Item(DomainObject):
+    # Create a BaseModel subclass.
+    class Item(BaseModel):
+        name: str = Field(default='default_name')
 
-        name = StringType(
-            default='default_name',
-            required=True
-        )
-
-    # Set the request context result to a list of DomainObjects.
+    # Set the result to a list of BaseModel instances.
     request_context.set_result([
-        DomainObject.new(Item, name='item1'),
-        DomainObject.new(Item, name='item2')
+        Item(name='item1'),
+        Item(name='item2'),
     ])
 
-    # Handle the response with a list of DomainObjects.
+    # Handle the response.
     response = request_context.handle_response()
 
-    # Check that the response is a list of dicts.
+    # Check the response.
     assert isinstance(response, list)
     assert len(response) == 2
     assert response[0].get('name') == 'item1'
@@ -174,47 +121,33 @@ def test_request_context_handle_response_domain_object_list(request_context: Fla
 # ** test: request_context_set_result_with_data_key
 def test_request_context_set_result_with_data_key(request_context: FlaskRequestContext):
     '''
-    Test that set_result with a data_key delegates to the parent method,
-    storing the result in request.data[data_key] instead of self.result.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
+    Test that set_result with a data_key delegates to the parent method.
     '''
 
-    # Set the result with a data_key.
     request_context.set_result('intermediate_value', data_key='step_result')
-
-    # Assert the result is stored in data, not in self.result.
     assert request_context.data['step_result'] == 'intermediate_value'
     assert request_context.result is None
 
-# ** test: request_context_handle_response_domain_object_dict
-def test_request_context_handle_response_domain_object_dict(request_context: FlaskRequestContext):
+# ** test: request_context_handle_response_base_model_dict
+def test_request_context_handle_response_base_model_dict(request_context: FlaskRequestContext):
     '''
-    Test handling a response that is a dict of DomainObjects.
-
-    :param request_context: The FlaskRequestContext instance.
-    :type request_context: FlaskRequestContext
+    Test handling a response that is a dict of BaseModel instances.
     '''
 
-    # Create a DomainObject to simulate a response.
-    class Item(DomainObject):
+    # Create a BaseModel subclass.
+    class Item(BaseModel):
+        name: str = Field(default='default_name')
 
-        name = StringType(
-            default='default_name',
-            required=True
-        )
-
-    # Set the request context result to a dict of DomainObjects.
+    # Set the result to a dict of BaseModel instances.
     request_context.set_result({
-        'item1': DomainObject.new(Item, name='item1'),
-        'item2': DomainObject.new(Item, name='item2')
+        'item1': Item(name='item1'),
+        'item2': Item(name='item2'),
     })
 
-    # Handle the response with a dict of DomainObjects.
+    # Handle the response.
     response = request_context.handle_response()
 
-    # Check that the response is a dict of dicts.
+    # Check the response.
     assert isinstance(response, dict)
     assert len(response) == 2
     assert response['item1'].get('name') == 'item1'


### PR DESCRIPTION
## Summary
Refactor `FlaskApiContext` to receive `DomainEvent` instances and migrate `FlaskRequestContext` to `BaseModel.model_dump()`, aligning with tiferet-fast patterns.

### Changes
- **`contexts/flask.py`** — Constructor now accepts `get_route_evt` and `get_status_code_evt` (`DomainEvent` instances) instead of raw callables. Removed `flask_app`, `get_blueprints_handler`, `build_blueprint()`, and `build_flask_app()`. `handle_error` now raises `TiferetAPIError` with `status_code` attribute (not tuple return). Added module-level docstring.
- **`contexts/request.py`** — Replaced `DomainObject.to_primitive()` with `BaseModel.model_dump()` for serialization. Added module-level docstring.
- **`contexts/__init__.py`** — Updated exports (`FlaskRequestContext` instead of `RequestContext`). Added docstring header.
- **`contexts/tests/test_flask.py`** — Fixtures use mock `DomainEvent` instances with `.execute`. Error tests verify `TiferetAPIError` is raised with `status_code`. Removed build_blueprint/build_flask_app tests. 4 tests pass.
- **`contexts/tests/test_request.py`** — Replaced `DomainObject`/`StringType` with `BaseModel`/`Field`. 8 tests pass.

Closes #34

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>