### PR TITLE
Packaging, Exports & Documentation (#36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Tiferet Flask (v0.2.0)
+# AGENTS.md — Tiferet Flask (v0.3.0)
 
 ## Project Overview
 
-**Tiferet Flask** is an extension of the Tiferet framework for building Flask-based APIs using Domain-Driven Design (DDD). It provides `FlaskApiContext`, `FlaskRequestContext`, domain objects, domain events, and a YAML-backed repository for Flask configuration.
+**Tiferet Flask** is an extension of the Tiferet framework for building Flask-based APIs using Domain-Driven Design (DDD). It provides `FlaskAppBuilder`, `FlaskApiContext`, `FlaskRequestContext`, Pydantic v2 domain objects, domain events, and a YAML-backed repository for Flask configuration.
 
 - **Repository:** https://github.com/greatstrength/tiferet-flask
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.2.0`
-- **Dependencies:** `tiferet >= 2.0.0a8`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
+- **Version:** `0.3.0`
+- **Dependencies:** `tiferet >= 2.0.0b1`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
 
 ## Architecture
 
@@ -16,31 +16,33 @@
 
 ```
 tiferet_flask/
-├── __init__.py          — Version and public exports
-├── domain/              — FlaskRoute, FlaskBlueprint (DomainObject)
+├── __init__.py          — Version and public exports (FlaskAppBuilder, FlaskApp)
+├── builders/            — FlaskAppBuilder (AppBuilder) — primary app entry point
+├── domain/              — FlaskRoute, FlaskBlueprint (DomainObject, Pydantic v2)
 ├── interfaces/          — FlaskApiService (Service)
-├── mappers/             — Aggregates and TransferObjects for YAML round-trip
-├── repos/               — FlaskYamlRepository (YAML-backed FlaskApiService)
+├── mappers/             — Aggregates (_ROLES ClassVar) and TransferObjects for YAML round-trip
+├── repos/               — FlaskYamlRepository (YamlLoader-backed FlaskApiService)
 ├── events/              — GetFlaskBlueprints, GetFlaskRoute, GetFlaskStatusCode (DomainEvent)
 └── contexts/            — FlaskApiContext (AppInterfaceContext), FlaskRequestContext (RequestContext)
 ```
 
 ### Key Concepts
 
-- **Domain Objects** (`domain/flask.py`): `FlaskRoute` and `FlaskBlueprint` — read-only domain models extending `DomainObject`.
-- **Service Interface** (`interfaces/flask.py`): `FlaskApiService` — abstract contract for Flask API configuration access (exists, get_blueprints, get_route, get_status_code, save, delete).
-- **Mappers** (`mappers/flask.py`): `FlaskRouteAggregate`, `FlaskBlueprintAggregate` (mutable), `FlaskRouteYamlObject`, `FlaskBlueprintYamlObject` (serialization).
-- **Repository** (`repos/flask.py`): `FlaskYamlRepository` — YAML-backed implementation of `FlaskApiService` using the `Yaml` utility.
-- **Domain Events** (`events/flask.py`): `GetFlaskBlueprints`, `GetFlaskRoute`, `GetFlaskStatusCode` — receive `FlaskApiService` via constructor injection.
-- **Contexts** (`contexts/flask.py`): `FlaskApiContext` — receives three callable handlers (`get_blueprints_handler`, `get_route_handler`, `get_status_code_handler`) resolved by the DI container.
+- **Domain Objects** (`domain/flask.py`): `FlaskRoute` and `FlaskBlueprint` — read-only Pydantic v2 domain models extending `DomainObject` with `Field` annotations. `FlaskRoute` includes an `endpoint` field (format: `blueprint_name.route_id`).
+- **Service Interface** (`interfaces/flask.py`): `FlaskApiService` — abstract contract for Flask API configuration access (`get_blueprints`, `get_route`, `get_status_code`). Returns domain objects, not aggregates.
+- **Mappers** (`mappers/flask.py`): `FlaskRouteAggregate`, `FlaskBlueprintAggregate` (mutable, direct Pydantic constructors), `FlaskRouteYamlObject`, `FlaskBlueprintYamlObject` (serialization via `_ROLES` ClassVar, `model_validate`, `@classmethod from_model`).
+- **Repository** (`repos/flask.py`): `FlaskYamlRepository` — `YamlLoader`-backed implementation of `FlaskApiService`. Uses `model_validate()` for YAML object construction. Constructor param: `flask_yaml_file`.
+- **Domain Events** (`events/flask.py`): `GetFlaskBlueprints`, `GetFlaskRoute`, `GetFlaskStatusCode` — receive `FlaskApiService` via constructor injection. Return domain objects.
+- **Contexts** (`contexts/flask.py`): `FlaskApiContext` — receives `DomainEvent` instances (`get_route_evt`, `get_status_code_evt`), wraps `.execute` internally. `handle_error` raises `TiferetAPIError` with `status_code`. `FlaskRequestContext` serializes via `BaseModel.model_dump()`.
+- **Builder** (`builders/flask.py`): `FlaskAppBuilder` — extends `tiferet.builders.AppBuilder`. Primary entry point for constructing Flask applications. Resolves `get_blueprints_evt` from service provider. Exported as `FlaskApp` alias.
 
 ### Runtime Flow
 
-1. `App()` loads settings and resolves the `calc_flask_api` interface.
-2. `FlaskApiContext` is instantiated with callable handlers backed by domain events.
-3. `build_flask_app()` calls `get_blueprints_handler()` to load blueprints and register Flask routes.
+1. `FlaskAppBuilder()` (or `FlaskApp()`) loads settings and service provider.
+2. `builder.run(interface_id, view_func)` loads the interface, assembles blueprints, and returns a Flask app.
+3. `FlaskApiContext` is instantiated with `DomainEvent` instances for route and status code lookup.
 4. On request, `view_func` calls `context.run()` which parses the request, executes the feature, and returns a response with status code.
-5. `handle_error` catches `TiferetAPIError` from the parent and returns a dict + status code tuple.
+5. `handle_error` raises `TiferetAPIError` with `status_code` attribute for error responses.
 
 ## Structured Code Style
 
@@ -52,14 +54,15 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 - **Test location:** Co-located in `<package>/tests/` directories.
 - **Run tests:** `pytest tiferet_flask/ -v`
 - **Patterns:**
-  - Domain/mapper tests use `DomainObject.new()` and `Aggregate.new()`.
+  - Domain/mapper tests use direct Pydantic constructors.
   - Event tests use `DomainEvent.handle()` with mocked `FlaskApiService`.
   - Repo tests are integration tests using `tmp_path` with real YAML files.
-  - Context tests use `mock.Mock()` callables for handler dependencies.
+  - Context tests use `mock.Mock(spec=DomainEvent)` for event dependencies.
 
 ## Key Files
 
 - `tiferet_flask/__init__.py` — Version and public exports
+- `tiferet_flask/builders/flask.py` — FlaskAppBuilder
 - `tiferet_flask/domain/flask.py` — FlaskRoute, FlaskBlueprint domain objects
 - `tiferet_flask/interfaces/flask.py` — FlaskApiService interface
 - `tiferet_flask/mappers/flask.py` — Aggregates and TransferObjects
@@ -67,3 +70,14 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 - `tiferet_flask/events/flask.py` — Domain events
 - `tiferet_flask/contexts/flask.py` — FlaskApiContext
 - `tiferet_flask/contexts/request.py` — FlaskRequestContext
+
+## Migration from v0.2.x
+
+- **Domain:** Schematics type descriptors → Pydantic v2 `Field` annotations. Added `endpoint` field to `FlaskRoute`.
+- **Mappers:** `Aggregate.new()` → direct Pydantic constructor. `class Options` → `_ROLES` ClassVar. `from_data()` → `model_validate()`. `from_model` → `@classmethod`.
+- **Interfaces:** Return types changed from aggregates to domain objects. Removed `exists`, `save`, `delete`.
+- **Events:** Return types changed from aggregates to domain objects. Imports from `..domain` instead of `..mappers`.
+- **Repository:** `Yaml` shorthand → `YamlLoader` composition. `flask_config_file` → `flask_yaml_file`. Removed `exists`, `save`, `delete`.
+- **Contexts:** `FlaskApiContext` accepts `DomainEvent` instances (not callables). Removed `build_blueprint`, `build_flask_app`, `get_blueprints_handler`, `flask_app`. `handle_error` raises `TiferetAPIError` (not tuple). `FlaskRequestContext` uses `BaseModel.model_dump()`.
+- **Builders:** New `FlaskAppBuilder` extending `AppBuilder`. Primary entry point for app construction.
+- **Dependency:** `tiferet>=2.0.0a8` → `tiferet>=2.0.0b1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet>=2.0.0a8",
+    "tiferet>=2.0.0b1",
     "flask>=3.1.2",
     "flask_cors>=6.0.1"
 ]

--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -15,4 +15,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary
Finalize v0.3.0 release packaging: update dependency, bump version, and update documentation.

### Changes
- **`pyproject.toml`** — Updated `tiferet>=2.0.0a8` to `tiferet>=2.0.0b1`.
- **`__init__.py`** — Version bumped to `0.3.0`. Kept existing export pipeline with builders added.
- **`AGENTS.md`** — Full rewrite for v0.3.0 architecture including new builders package, Pydantic v2 domain objects, _ROLES ClassVar mappers, YamlLoader repo, DomainEvent context injection, and v0.2.x migration guide.

All 39 tests pass. `pip install -e .[test]` succeeds.

Closes #36

---
[Warp conversation](https://app.warp.dev/conversation/63dc758e-5977-404e-832e-e2473bf8cd44)

Co-Authored-By: Oz <oz-agent@warp.dev>