### PR TITLE
Adopt tiferet-openapi for Contexts and Builders (#46, #47)

### DIFF
--- a/tiferet_flask/builders/flask.py
+++ b/tiferet_flask/builders/flask.py
@@ -1,4 +1,4 @@
-"""Flask API Builder."""
+'''Flask API Builder.'''
 
 # *** imports
 
@@ -9,10 +9,8 @@ from typing import Callable, List
 from flask import Flask, Blueprint
 from flask_cors import CORS
 from tiferet.builders import AppBuilder
+from tiferet_openapi import ApiRouter
 
-# ** app
-from ..domain import FlaskBlueprint
-from ..contexts import FlaskApiContext
 
 # *** builders
 
@@ -22,26 +20,26 @@ class FlaskAppBuilder(AppBuilder):
     Specialized application builder for Flask applications.
     '''
 
-    # * method: get_blueprints
-    def get_blueprints(self) -> List[FlaskBlueprint]:
+    # * method: get_routers
+    def get_routers(self) -> List[ApiRouter]:
         '''
-        Resolve and execute the get_blueprints event from the service provider.
+        Resolve and execute the get_routers event from the service provider.
 
-        :return: A list of FlaskBlueprint domain objects.
-        :rtype: List[FlaskBlueprint]
+        :return: A list of ApiRouter domain objects.
+        :rtype: List[ApiRouter]
         '''
 
-        # Resolve the get_blueprints event and execute it.
-        get_blueprints_evt = self.service_provider.get_service('get_blueprints_evt')
-        return get_blueprints_evt.execute()
+        # Resolve the get_routers event and execute it.
+        get_routers_evt = self.service_provider.get_service('get_routers_evt')
+        return get_routers_evt.execute()
 
     # * method: build_blueprint
-    def build_blueprint(self, flask_blueprint: FlaskBlueprint, view_func: Callable, **kwargs) -> Blueprint:
+    def build_blueprint(self, router: ApiRouter, view_func: Callable, **kwargs) -> Blueprint:
         '''
-        Build a Flask Blueprint from a FlaskBlueprint domain object.
+        Build a Flask Blueprint from an ApiRouter domain object.
 
-        :param flask_blueprint: The FlaskBlueprint domain object.
-        :type flask_blueprint: FlaskBlueprint
+        :param router: The ApiRouter domain object.
+        :type router: ApiRouter
         :param view_func: The view function to handle requests.
         :type view_func: Callable
         :param kwargs: Additional keyword arguments.
@@ -52,15 +50,15 @@ class FlaskAppBuilder(AppBuilder):
 
         # Create the Flask Blueprint.
         blueprint = Blueprint(
-            flask_blueprint.name,
+            router.name,
             __name__,
-            url_prefix=flask_blueprint.url_prefix,
+            url_prefix=router.prefix,
         )
 
-        # Add routes from the FlaskBlueprint domain object.
-        for route in flask_blueprint.routes:
+        # Add routes from the ApiRouter domain object.
+        for route in router.routes:
             blueprint.add_url_rule(
-                route.rule,
+                route.path,
                 route.id,
                 methods=route.methods,
                 view_func=view_func,
@@ -91,10 +89,10 @@ class FlaskAppBuilder(AppBuilder):
         flask_app = Flask(__name__)
         CORS(flask_app)
 
-        # Load and register blueprints.
-        blueprints = self.get_blueprints()
-        for bp in blueprints:
-            blueprint = self.build_blueprint(bp, view_func=view_func, **kwargs)
+        # Load and register routers as blueprints.
+        routers = self.get_routers()
+        for router in routers:
+            blueprint = self.build_blueprint(router, view_func=view_func, **kwargs)
             flask_app.register_blueprint(blueprint)
 
         # Return the assembled Flask application.

--- a/tiferet_flask/contexts/flask.py
+++ b/tiferet_flask/contexts/flask.py
@@ -1,139 +1,16 @@
-"""Flask API context."""
+'''Flask API context.'''
 
 # *** imports
 
-# ** core
-from typing import Any, Callable
-
 # ** infra
-from tiferet import TiferetError
-from tiferet.assets.exceptions import TiferetAPIError
-from tiferet.contexts import (
-    AppInterfaceContext,
-    FeatureContext,
-    ErrorContext,
-    LoggingContext,
-)
-from tiferet.events import DomainEvent
+from tiferet_openapi import OpenApiContext
 
-# ** app
-from .request import FlaskRequestContext
 
 # *** contexts
 
 # ** context: flask_api_context
-class FlaskApiContext(AppInterfaceContext):
+class FlaskApiContext(OpenApiContext):
     '''
-    A context for managing Flask API interactions within the Tiferet framework.
+    A Flask-specific API context extending the shared OpenAPI context.
     '''
-
-    # * attribute: get_route_handler
-    get_route_handler: Callable
-
-    # * attribute: get_status_code_handler
-    get_status_code_handler: Callable
-
-    # * init
-    def __init__(self,
-            interface_id: str,
-            features: FeatureContext,
-            errors: ErrorContext,
-            logging: LoggingContext,
-            get_route_evt: DomainEvent,
-            get_status_code_evt: DomainEvent,
-        ):
-        '''
-        Initialize the Flask API context.
-
-        :param interface_id: The interface ID.
-        :type interface_id: str
-        :param features: The feature context.
-        :type features: FeatureContext
-        :param errors: The error context.
-        :type errors: ErrorContext
-        :param logging: The logging context.
-        :type logging: LoggingContext
-        :param get_route_evt: The domain event for retrieving a route.
-        :type get_route_evt: DomainEvent
-        :param get_status_code_evt: The domain event for retrieving a status code.
-        :type get_status_code_evt: DomainEvent
-        '''
-
-        # Call the parent constructor.
-        super().__init__(interface_id, features, errors, logging)
-
-        # Set the domain event handlers.
-        self.get_route_handler = get_route_evt.execute
-        self.get_status_code_handler = get_status_code_evt.execute
-
-    # * method: parse_request
-    def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> FlaskRequestContext:
-        '''
-        Parse the incoming request and return a FlaskRequestContext instance.
-
-        :param headers: The request headers.
-        :type headers: dict
-        :param data: The request data.
-        :type data: dict
-        :param feature_id: The feature ID.
-        :type feature_id: str
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: A FlaskRequestContext instance.
-        :rtype: FlaskRequestContext
-        '''
-
-        # Return a FlaskRequestContext instance.
-        return FlaskRequestContext(
-            headers=headers,
-            data=data,
-            feature_id=feature_id,
-        )
-
-    # * method: handle_error
-    def handle_error(self, error: Exception, **kwargs) -> Any:
-        '''
-        Handle the error and raise TiferetAPIError with status_code.
-
-        :param error: The error to handle.
-        :type error: Exception
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The error response.
-        :rtype: Any
-        '''
-
-        # Get the status code via event if it's a TiferetError.
-        if isinstance(error, TiferetError):
-            status_code = self.get_status_code_handler(error_code=error.error_code)
-        else:
-            status_code = 500
-
-        # Delegate formatting to parent (which raises TiferetAPIError).
-        try:
-            return super().handle_error(error, **kwargs)
-        except TiferetAPIError as api_error:
-            api_error.status_code = status_code
-            raise
-
-    # * method: handle_response
-    def handle_response(self, request: FlaskRequestContext, **kwargs) -> Any:
-        '''
-        Handle the response from the request context.
-
-        :param request: The request context.
-        :type request: FlaskRequestContext
-        :param kwargs: Additional keyword arguments.
-        :type kwargs: dict
-        :return: The response and status code.
-        :rtype: Any
-        '''
-
-        # Handle the response from the request context.
-        response = super().handle_response(request, **kwargs)
-
-        # Retrieve the route by the request feature id.
-        route = self.get_route_handler(endpoint=request.feature_id)
-
-        # Return the result with the specified status code.
-        return response, route.status_code if route else 200
+    pass

--- a/tiferet_flask/contexts/request.py
+++ b/tiferet_flask/contexts/request.py
@@ -1,72 +1,13 @@
-"""Flask request context."""
+'''Flask request context.'''
 
 # *** imports
 
-# ** core
-from typing import Any
-
 # ** infra
-from pydantic import BaseModel
-from tiferet.contexts.request import RequestContext
+from tiferet_openapi import OpenApiRequestContext
+
 
 # *** contexts
 
 # ** context: flask_request_context
-class FlaskRequestContext(RequestContext):
-    '''
-    A context for handling Flask API request data and responses.
-    '''
-
-    # * method: handle_response
-    def handle_response(self) -> Any:
-        '''
-        Handle the response for the Flask request context.
-
-        :return: The response.
-        :rtype: Any
-        '''
-
-        # Set the result using the set_result method to ensure proper formatting.
-        self.set_result(self.result)
-
-        # Handle the response using the parent method.
-        return super().handle_response()
-
-    # * method: set_result
-    def set_result(self, result: Any, data_key: str = None):
-        '''
-        Set the result of the request context.
-
-        :param result: The result to set.
-        :type result: Any
-        :param data_key: The key in the request data to set the result to.
-            If provided, the raw result is stored for downstream commands.
-            If None, the result is serialized for the final response.
-        :type data_key: str
-        '''
-
-        # If a data key is provided, delegate to the parent to store the raw result.
-        if data_key:
-            super().set_result(result, data_key=data_key)
-            return
-
-        # If the response is None, return an empty response.
-        if result is None:
-            self.result = ''
-
-        # Convert the response to a dictionary if it's a BaseModel.
-        elif isinstance(result, BaseModel):
-            self.result = result.model_dump()
-
-        # If the response is a list containing BaseModel instances, convert each to a dictionary.
-        elif isinstance(result, list) and all(isinstance(item, BaseModel) for item in result):
-            self.result = [item.model_dump() for item in result]
-
-        # If the response is a dict containing BaseModel instances, convert each to a dictionary.
-        elif isinstance(result, dict) and all(isinstance(value, BaseModel) for value in result.values()):
-            self.result = {key: value.model_dump() for key, value in result.items()}
-
-        # Otherwise, set the result directly.
-        else:
-            self.result = result
+FlaskRequestContext = OpenApiRequestContext
 

--- a/tiferet_flask/contexts/tests/test_flask.py
+++ b/tiferet_flask/contexts/tests/test_flask.py
@@ -9,32 +9,32 @@ from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
 from tiferet import TiferetError
 from tiferet.events import DomainEvent
+from tiferet_openapi import ApiRoute
 
 # ** app
 from ..flask import FlaskApiContext
 from ..request import FlaskRequestContext
-from ...domain import FlaskRoute
 
 # *** fixtures
 
 # ** fixture: sample_route
 @pytest.fixture
-def sample_route() -> FlaskRoute:
+def sample_route() -> ApiRoute:
     '''
-    Fixture to provide a sample FlaskRoute.
+    Fixture to provide a sample ApiRoute.
     '''
 
-    return FlaskRoute(
+    return ApiRoute(
         id='sample_route',
-        endpoint='sample_blueprint.sample_route',
-        rule='/sample',
+        endpoint='sample_router.sample_route',
+        path='/sample',
         methods=['GET', 'POST'],
         status_code=269,
     )
 
 # ** fixture: flask_api_context
 @pytest.fixture
-def flask_api_context(sample_route: FlaskRoute) -> FlaskApiContext:
+def flask_api_context(sample_route: ApiRoute) -> FlaskApiContext:
     '''
     Fixture to provide a FlaskApiContext instance for testing.
     '''
@@ -50,6 +50,8 @@ def flask_api_context(sample_route: FlaskRoute) -> FlaskApiContext:
     mock_get_route_evt.execute = mock.Mock(return_value=sample_route)
     mock_get_status_code_evt = mock.Mock(spec=DomainEvent)
     mock_get_status_code_evt.execute = mock.Mock(return_value=420)
+    mock_get_routers_evt = mock.Mock(spec=DomainEvent)
+    mock_get_routers_evt.execute = mock.Mock(return_value=[])
 
     # Create and return the FlaskApiContext instance.
     return FlaskApiContext(
@@ -59,6 +61,7 @@ def flask_api_context(sample_route: FlaskRoute) -> FlaskApiContext:
         logging=mock_logging,
         get_route_evt=mock_get_route_evt,
         get_status_code_evt=mock_get_status_code_evt,
+        get_routers_evt=mock_get_routers_evt,
     )
 
 # *** tests


### PR DESCRIPTION
## Summary

Combined implementation of #46 and #47 — adopts `tiferet-openapi` v0.1.1 types for both contexts and builders.

### Contexts (#46)
- `FlaskApiContext` → thin subclass of `OpenApiContext` (inherits all behavior including `get_routers_handler`, `generate_spec()`, `create_docs_handler()`).
- `FlaskRequestContext` → alias for `OpenApiRequestContext`.
- Updated tests to use `ApiRoute` from `tiferet_openapi` and include `get_routers_evt` mock (required by `OpenApiContext.__init__`).

### Builders (#47)
- Replaced `FlaskBlueprint` import with `ApiRouter` from `tiferet_openapi`.
- Renamed `get_blueprints()` → `get_routers()` (resolves `get_routers_evt` from service provider).
- Updated `build_blueprint()` to map `ApiRouter.prefix` → `url_prefix`, `ApiRoute.path` → URL rule.

### Deviation from TRDs
- **Combined into single branch/PR** since tiferet-openapi v0.1.1 already includes `get_routers_handler` and `generate_spec()` on `OpenApiContext`, making the two issues naturally interdependent.
- **`FlaskApiContext` constructor**: TRD #46 expected no `get_routers_evt` parameter — but `OpenApiContext` v0.1.1 already requires it, so it's inherited automatically.

### Test Results
All 12 tests pass. All top-level imports (`FlaskAppBuilder`, `FlaskApp`, `FlaskApiContext`, `FlaskRequestContext`) work.

Closes #46
Closes #47

---
[Warp conversation](https://app.warp.dev/conversation/a1f7a3e1-ed18-4a39-b0bc-af1dd660b26e)

Co-Authored-By: Oz <oz-agent@warp.dev>