### PR TITLE
Contexts – Add Swagger Documentation to FlaskApiContext (#48)

### DIFF
--- a/tiferet_flask/builders/flask.py
+++ b/tiferet_flask/builders/flask.py
@@ -68,7 +68,7 @@ class FlaskAppBuilder(AppBuilder):
         return blueprint
 
     # * method: build_flask_app
-    def build_flask_app(self, interface_id: str, view_func: Callable, **kwargs) -> Flask:
+    def build_flask_app(self, interface_id: str, view_func: Callable, swagger: bool = False, **kwargs) -> Flask:
         '''
         Build a complete Flask application with CORS and blueprints.
 
@@ -76,6 +76,8 @@ class FlaskAppBuilder(AppBuilder):
         :type interface_id: str
         :param view_func: The view function to handle requests.
         :type view_func: Callable
+        :param swagger: Whether to register a Swagger UI blueprint.
+        :type swagger: bool
         :param kwargs: Additional keyword arguments.
         :type kwargs: dict
         :return: A configured Flask application instance.
@@ -94,6 +96,11 @@ class FlaskAppBuilder(AppBuilder):
         for router in routers:
             blueprint = self.build_blueprint(router, view_func=view_func, **kwargs)
             flask_app.register_blueprint(blueprint)
+
+        # Optionally register the swagger blueprint.
+        if swagger and hasattr(interface_context, 'create_swagger_blueprint'):
+            swagger_bp = interface_context.create_swagger_blueprint(**kwargs)
+            flask_app.register_blueprint(swagger_bp)
 
         # Return the assembled Flask application.
         return flask_app

--- a/tiferet_flask/contexts/flask.py
+++ b/tiferet_flask/contexts/flask.py
@@ -3,6 +3,7 @@
 # *** imports
 
 # ** infra
+from flask import Blueprint, Response, jsonify
 from tiferet_openapi import OpenApiContext
 
 
@@ -13,4 +14,59 @@ class FlaskApiContext(OpenApiContext):
     '''
     A Flask-specific API context extending the shared OpenAPI context.
     '''
-    pass
+
+    # * method: create_swagger_blueprint
+    def create_swagger_blueprint(self, title: str = 'API', version: str = '1.0.0', description: str = '') -> Blueprint:
+        '''
+        Create a Flask Blueprint serving Swagger UI and the OpenAPI spec.
+
+        :param title: The API title.
+        :type title: str
+        :param version: The API version.
+        :type version: str
+        :param description: The API description.
+        :type description: str
+        :return: A Flask Blueprint serving /docs and /docs/openapi.json.
+        :rtype: Blueprint
+        '''
+
+        # Generate the OpenAPI spec.
+        spec = self.generate_spec(title=title, version=version, description=description)
+
+        # Create the swagger blueprint.
+        swagger_bp = Blueprint('swagger', __name__, url_prefix='/docs')
+
+        # Register the JSON spec endpoint.
+        @swagger_bp.route('/openapi.json')
+        def openapi_json():
+            return jsonify(spec)
+
+        # Register the Swagger UI endpoint (CDN-hosted, no extra dependency).
+        @swagger_bp.route('/')
+        def swagger_ui():
+            html = f'''<!DOCTYPE html>
+<html><head><title>{title} - Docs</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css">
+</head><body>
+<div id="swagger-ui"></div>
+<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+<script>SwaggerUIBundle({{url: "/docs/openapi.json", dom_id: "#swagger-ui"}})</script>
+</body></html>'''
+            return Response(html, content_type='text/html')
+
+        # Return the swagger blueprint.
+        return swagger_bp
+
+    # * method: create_docs_handler
+    def create_docs_handler(self, **kwargs):
+        '''
+        Override base create_docs_handler to return a Flask Swagger Blueprint.
+
+        :param kwargs: Keyword arguments passed to create_swagger_blueprint.
+        :type kwargs: dict
+        :return: A Flask Blueprint serving Swagger UI.
+        :rtype: Blueprint
+        '''
+
+        # Delegate to create_swagger_blueprint.
+        return self.create_swagger_blueprint(**kwargs)

--- a/tiferet_flask/contexts/tests/test_flask.py
+++ b/tiferet_flask/contexts/tests/test_flask.py
@@ -3,13 +3,14 @@
 # ** infra
 import pytest
 from unittest import mock
+from flask import Blueprint
 from tiferet.assets.exceptions import TiferetAPIError
 from tiferet.contexts.error import ErrorContext
 from tiferet.contexts.feature import FeatureContext
 from tiferet.contexts.logging import LoggingContext
 from tiferet import TiferetError
 from tiferet.events import DomainEvent
-from tiferet_openapi import ApiRoute
+from tiferet_openapi import ApiRoute, ApiRouter
 
 # ** app
 from ..flask import FlaskApiContext
@@ -153,3 +154,98 @@ def test_flask_api_context_handle_response(flask_api_context: FlaskApiContext):
     flask_api_context.get_route_handler.assert_called_once_with(
         endpoint='test_feature'
     )
+
+# ** test: flask_api_context_generate_spec_single_router
+def test_flask_api_context_generate_spec_single_router(flask_api_context: FlaskApiContext):
+    '''
+    Test generate_spec with a single router containing multiple routes.
+    '''
+
+    # Set up the routers mock to return a single router.
+    sample_router = ApiRouter(
+        name='calc',
+        prefix='/calc',
+        routes=[
+            ApiRoute(id='add', endpoint='calc.add', path='/add', methods=['POST'], status_code=200),
+            ApiRoute(id='subtract', endpoint='calc.subtract', path='/subtract', methods=['POST'], status_code=200),
+        ],
+    )
+    flask_api_context.get_routers_handler = mock.Mock(return_value=[sample_router])
+
+    # Generate the spec.
+    spec = flask_api_context.generate_spec(title='Calc API', version='2.0.0', description='A calculator')
+
+    # Assert the spec structure.
+    assert spec['openapi'] == '3.0.3'
+    assert spec['info']['title'] == 'Calc API'
+    assert spec['info']['version'] == '2.0.0'
+    assert spec['info']['description'] == 'A calculator'
+    assert '/calc/add' in spec['paths']
+    assert '/calc/subtract' in spec['paths']
+    assert spec['paths']['/calc/add']['post']['operationId'] == 'calc.add'
+
+# ** test: flask_api_context_generate_spec_multi_router
+def test_flask_api_context_generate_spec_multi_router(flask_api_context: FlaskApiContext):
+    '''
+    Test generate_spec with multiple routers.
+    '''
+
+    # Set up the routers mock to return two routers.
+    routers = [
+        ApiRouter(
+            name='calc',
+            prefix='/calc',
+            routes=[ApiRoute(id='add', endpoint='calc.add', path='/add', methods=['POST'], status_code=200)],
+        ),
+        ApiRouter(
+            name='health',
+            prefix=None,
+            routes=[ApiRoute(id='ping', endpoint='health.ping', path='/ping', methods=['GET'], status_code=200)],
+        ),
+    ]
+    flask_api_context.get_routers_handler = mock.Mock(return_value=routers)
+
+    # Generate the spec.
+    spec = flask_api_context.generate_spec()
+
+    # Assert paths from both routers are present.
+    assert '/calc/add' in spec['paths']
+    assert '/ping' in spec['paths']
+    assert spec['info']['title'] == 'API'
+
+# ** test: flask_api_context_create_swagger_blueprint
+def test_flask_api_context_create_swagger_blueprint(flask_api_context: FlaskApiContext):
+    '''
+    Test create_swagger_blueprint returns a Flask Blueprint with correct routes.
+    '''
+
+    # Set up routers mock.
+    flask_api_context.get_routers_handler = mock.Mock(return_value=[])
+
+    # Create the swagger blueprint.
+    swagger_bp = flask_api_context.create_swagger_blueprint(title='Test API')
+
+    # Assert it is a Blueprint with the expected name and prefix.
+    assert isinstance(swagger_bp, Blueprint)
+    assert swagger_bp.name == 'swagger'
+    assert swagger_bp.url_prefix == '/docs'
+
+    # Assert the blueprint has the expected deferred view functions.
+    rules = [rule for rule in swagger_bp.deferred_functions]
+    assert len(rules) == 2  # openapi_json and swagger_ui
+
+# ** test: flask_api_context_create_docs_handler
+def test_flask_api_context_create_docs_handler(flask_api_context: FlaskApiContext):
+    '''
+    Test create_docs_handler delegates to create_swagger_blueprint.
+    '''
+
+    # Set up routers mock.
+    flask_api_context.get_routers_handler = mock.Mock(return_value=[])
+
+    # Call create_docs_handler.
+    result = flask_api_context.create_docs_handler(title='Docs API')
+
+    # Assert it returns a Blueprint.
+    assert isinstance(result, Blueprint)
+    assert result.name == 'swagger'


### PR DESCRIPTION
## Summary

Adds OpenAPI 3.0 spec generation and Swagger UI serving to `FlaskApiContext`, plus `swagger=True` support in `FlaskAppBuilder`.

### Changes

**FlaskApiContext** (`contexts/flask.py`):
- `create_swagger_blueprint(title, version, description)` — creates a Flask Blueprint serving `/docs` (Swagger UI via CDN) and `/docs/openapi.json`.
- `create_docs_handler(**kwargs)` — overrides the base `OpenApiContext` no-op to delegate to `create_swagger_blueprint()`.
- `generate_spec()` is inherited from `OpenApiContext` v0.1.1 (no hardcoding needed).

**FlaskAppBuilder** (`builders/flask.py`):
- `build_flask_app()` now accepts `swagger: bool = False`. When `True`, registers the swagger blueprint from the interface context.

**Tests** (4 new):
- `test_generate_spec_single_router` — verifies OpenAPI 3.0 spec with prefixed paths.
- `test_generate_spec_multi_router` — verifies multiple routers including null prefix.
- `test_create_swagger_blueprint` — verifies Blueprint name, prefix, and deferred routes.
- `test_create_docs_handler` — verifies delegation to `create_swagger_blueprint`.

### Deviations from TRD
- **`get_routers_evt` and `generate_spec()`**: TRD expected these to be hardcoded on `FlaskApiContext`. Since `OpenApiContext` v0.1.1 already provides both, they are simply inherited — no code needed.
- **`create_docs_handler()` override**: Added as the clean integration point (TRD mentioned `create_docs_handler` was a no-op on the base; we override it here).

### Test Results
All 16 tests pass (12 existing + 4 new). No new dependencies.

Closes #48

---
[Warp conversation](https://app.warp.dev/conversation/a1f7a3e1-ed18-4a39-b0bc-af1dd660b26e)

Co-Authored-By: Oz <oz-agent@warp.dev>