### PR TITLE
Packaging – Version Bump, Exports, README, and AGENTS.md (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Tiferet Flask (v0.3.0)
+# AGENTS.md — Tiferet Flask (v0.4.0)
 
 ## Project Overview
 
-**Tiferet Flask** is an extension of the Tiferet framework for building Flask-based APIs using Domain-Driven Design (DDD). It provides `FlaskAppBuilder`, `FlaskApiContext`, `FlaskRequestContext`, Pydantic v2 domain objects, domain events, and a YAML-backed repository for Flask configuration.
+**Tiferet Flask** is a Flask extension for the Tiferet framework, providing Flask-specific API building and Swagger UI support on top of the shared [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) abstraction layer. All domain objects, service interfaces, domain events, mappers, and repositories are provided by `tiferet-openapi`.
 
 - **Repository:** https://github.com/greatstrength/tiferet-flask
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.3.0`
-- **Dependencies:** `tiferet >= 2.0.0b1`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
+- **Version:** `0.4.0`
+- **Dependencies:** `tiferet >= 2.0.0b1`, `tiferet-openapi >= 0.1.1`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
 
 ## Architecture
 
@@ -16,33 +16,51 @@
 
 ```
 tiferet_flask/
-├── __init__.py          — Version and public exports (FlaskAppBuilder, FlaskApp)
-├── builders/            — FlaskAppBuilder (AppBuilder) — primary app entry point
-├── domain/              — FlaskRoute, FlaskBlueprint (DomainObject, Pydantic v2)
-├── interfaces/          — FlaskApiService (Service)
-├── mappers/             — Aggregates (_ROLES ClassVar) and TransferObjects for YAML round-trip
-├── repos/               — FlaskYamlRepository (YamlLoader-backed FlaskApiService)
-├── events/              — GetFlaskBlueprints, GetFlaskRoute, GetFlaskStatusCode (DomainEvent)
-└── contexts/            — FlaskApiContext (AppInterfaceContext), FlaskRequestContext (RequestContext)
+├── __init__.py          — Version (0.4.0) and public exports
+├── builders/            — FlaskAppBuilder (AppBuilder) with swagger support
+└── contexts/            — FlaskApiContext (OpenApiContext), FlaskRequestContext (alias)
 ```
+
+All domain, interface, event, mapper, and repository layers are provided by `tiferet-openapi`. No `domain/`, `interfaces/`, `events/`, `mappers/`, or `repos/` packages exist under `tiferet_flask/`.
 
 ### Key Concepts
 
-- **Domain Objects** (`domain/flask.py`): `FlaskRoute` and `FlaskBlueprint` — read-only Pydantic v2 domain models extending `DomainObject` with `Field` annotations. `FlaskRoute` includes an `endpoint` field (format: `blueprint_name.route_id`).
-- **Service Interface** (`interfaces/flask.py`): `FlaskApiService` — abstract contract for Flask API configuration access (`get_blueprints`, `get_route`, `get_status_code`). Returns domain objects, not aggregates.
-- **Mappers** (`mappers/flask.py`): `FlaskRouteAggregate`, `FlaskBlueprintAggregate` (mutable, direct Pydantic constructors), `FlaskRouteYamlObject`, `FlaskBlueprintYamlObject` (serialization via `_ROLES` ClassVar, `model_validate`, `@classmethod from_model`).
-- **Repository** (`repos/flask.py`): `FlaskYamlRepository` — `YamlLoader`-backed implementation of `FlaskApiService`. Uses `model_validate()` for YAML object construction. Constructor param: `flask_yaml_file`.
-- **Domain Events** (`events/flask.py`): `GetFlaskBlueprints`, `GetFlaskRoute`, `GetFlaskStatusCode` — receive `FlaskApiService` via constructor injection. Return domain objects.
-- **Contexts** (`contexts/flask.py`): `FlaskApiContext` — receives `DomainEvent` instances (`get_route_evt`, `get_status_code_evt`), wraps `.execute` internally. `handle_error` raises `TiferetAPIError` with `status_code`. `FlaskRequestContext` serializes via `BaseModel.model_dump()`.
-- **Builder** (`builders/flask.py`): `FlaskAppBuilder` — extends `tiferet.builders.AppBuilder`. Primary entry point for constructing Flask applications. Resolves `get_blueprints_evt` from service provider. Exported as `FlaskApp` alias.
+- **FlaskAppBuilder** (`builders/flask.py`): Extends `tiferet.builders.AppBuilder`. Consumes `ApiRouter`/`ApiRoute` from `tiferet_openapi`. Methods: `get_routers()`, `build_blueprint(router, view_func)`, `build_flask_app(interface_id, view_func, swagger=False)`, `run()`. Exported as `FlaskApp` alias.
+- **FlaskApiContext** (`contexts/flask.py`): Thin subclass of `tiferet_openapi.OpenApiContext`. Inherits `parse_request()`, `handle_error()`, `handle_response()`, `generate_spec()`, `get_routers_handler`. Adds `create_swagger_blueprint(title, version, description)` and overrides `create_docs_handler()` to delegate to it.
+- **FlaskRequestContext** (`contexts/request.py`): Alias for `tiferet_openapi.OpenApiRequestContext`. Provides Pydantic `BaseModel.model_dump()` serialization for responses.
+
+### Domain Types (from tiferet-openapi)
+
+- `ApiRoute` — route with `id`, `endpoint`, `path`, `methods`, `status_code`.
+- `ApiRouter` — router with `name`, `prefix`, `routes`.
+- `OpenApiService` — service interface for route/router/status code access.
+- `GetRouters`, `GetRoute`, `GetStatusCode` — domain events.
+- `OpenApiYamlRepository` — YAML-backed service implementation.
 
 ### Runtime Flow
 
-1. `FlaskAppBuilder()` (or `FlaskApp()`) loads settings and service provider.
-2. `builder.run(interface_id, view_func)` loads the interface, assembles blueprints, and returns a Flask app.
-3. `FlaskApiContext` is instantiated with `DomainEvent` instances for route and status code lookup.
-4. On request, `view_func` calls `context.run()` which parses the request, executes the feature, and returns a response with status code.
-5. `handle_error` raises `TiferetAPIError` with `status_code` attribute for error responses.
+1. `FlaskAppBuilder()` loads settings and service provider.
+2. `builder.run(interface_id, view_func, swagger=True)` loads the interface, assembles Flask Blueprints from `ApiRouter` objects, optionally registers the Swagger UI blueprint, and returns a Flask app.
+3. `FlaskApiContext` (via `OpenApiContext`) handles request parsing, feature execution, error handling with status codes, and response formatting.
+4. On request, `view_func` calls `context.run()` → parses request → executes feature → returns `(response, status_code)`.
+
+### YAML Configuration
+
+Uses the `openapi:` root key (not `flask:`):
+
+```yaml
+openapi:
+  routers:
+    calc:
+      prefix: /calc
+      routes:
+        add:
+          path: /add
+          methods: [POST, GET]
+          status_code: 200
+  errors:
+    DIVISION_BY_ZERO: 400
+```
 
 ## Structured Code Style
 
@@ -51,33 +69,24 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 ## Testing
 
 - **Framework:** `pytest`
-- **Test location:** Co-located in `<package>/tests/` directories.
+- **Test location:** Co-located in `contexts/tests/`.
 - **Run tests:** `pytest tiferet_flask/ -v`
 - **Patterns:**
-  - Domain/mapper tests use direct Pydantic constructors.
-  - Event tests use `DomainEvent.handle()` with mocked `FlaskApiService`.
-  - Repo tests are integration tests using `tmp_path` with real YAML files.
-  - Context tests use `mock.Mock(spec=DomainEvent)` for event dependencies.
+  - Context tests use `mock.Mock(spec=DomainEvent)` for event dependencies and `ApiRoute`/`ApiRouter` from `tiferet_openapi`.
+  - Swagger tests verify `generate_spec()` output structure and `create_swagger_blueprint()` returns a Flask Blueprint.
 
 ## Key Files
 
 - `tiferet_flask/__init__.py` — Version and public exports
 - `tiferet_flask/builders/flask.py` — FlaskAppBuilder
-- `tiferet_flask/domain/flask.py` — FlaskRoute, FlaskBlueprint domain objects
-- `tiferet_flask/interfaces/flask.py` — FlaskApiService interface
-- `tiferet_flask/mappers/flask.py` — Aggregates and TransferObjects
-- `tiferet_flask/repos/flask.py` — FlaskYamlRepository
-- `tiferet_flask/events/flask.py` — Domain events
-- `tiferet_flask/contexts/flask.py` — FlaskApiContext
-- `tiferet_flask/contexts/request.py` — FlaskRequestContext
+- `tiferet_flask/contexts/flask.py` — FlaskApiContext (OpenApiContext subclass with Swagger)
+- `tiferet_flask/contexts/request.py` — FlaskRequestContext (alias for OpenApiRequestContext)
 
-## Migration from v0.2.x
+## Migration from v0.3.x
 
-- **Domain:** Schematics type descriptors → Pydantic v2 `Field` annotations. Added `endpoint` field to `FlaskRoute`.
-- **Mappers:** `Aggregate.new()` → direct Pydantic constructor. `class Options` → `_ROLES` ClassVar. `from_data()` → `model_validate()`. `from_model` → `@classmethod`.
-- **Interfaces:** Return types changed from aggregates to domain objects. Removed `exists`, `save`, `delete`.
-- **Events:** Return types changed from aggregates to domain objects. Imports from `..domain` instead of `..mappers`.
-- **Repository:** `Yaml` shorthand → `YamlLoader` composition. `flask_config_file` → `flask_yaml_file`. Removed `exists`, `save`, `delete`.
-- **Contexts:** `FlaskApiContext` accepts `DomainEvent` instances (not callables). Removed `build_blueprint`, `build_flask_app`, `get_blueprints_handler`, `flask_app`. `handle_error` raises `TiferetAPIError` (not tuple). `FlaskRequestContext` uses `BaseModel.model_dump()`.
-- **Builders:** New `FlaskAppBuilder` extending `AppBuilder`. Primary entry point for app construction.
-- **Dependency:** `tiferet>=2.0.0a8` → `tiferet>=2.0.0b1`.
+- **Deleted packages:** `domain/`, `interfaces/`, `events/`, `mappers/`, `repos/` — all replaced by `tiferet-openapi>=0.1.1`.
+- **Contexts:** `FlaskApiContext` now extends `OpenApiContext` (not `AppInterfaceContext`). Constructor requires `get_routers_evt` in addition to `get_route_evt` and `get_status_code_evt`. `FlaskRequestContext` is now an alias for `OpenApiRequestContext`.
+- **Builders:** `get_blueprints()` → `get_routers()`. `build_blueprint()` accepts `ApiRouter` (not `FlaskBlueprint`). `build_flask_app()` accepts `swagger=True`.
+- **Configuration:** `flask:` root key → `openapi:` root key. `blueprints` → `routers`. `url_prefix` → `prefix`. `rule` → `path`. `flask_config_file` → `openapi_yaml_file`.
+- **Imports:** Domain types (`FlaskRoute`, `FlaskBlueprint`, etc.) no longer exported from `tiferet_flask`. Import `ApiRoute`, `ApiRouter`, etc. from `tiferet_openapi`.
+- **Dependency:** Added `tiferet-openapi>=0.1.1`.

--- a/README.md
+++ b/README.md
@@ -2,265 +2,178 @@
 
 ## Introduction
 
-Tiferet Flask elevates the Tiferet Python framework by empowering developers to craft sophisticated Flask-based APIs rooted in Domain-Driven Design (DDD) principles. Drawing from the Kabbalistic ideal of beauty in harmony, Tiferet Flask seamlessly blends Tiferet's domain event-driven architecture with Flask's intuitive routing and request handling. The result is a powerful, modular platform for building scalable web services that distill complex business logic into elegant, extensible API designs.
+Tiferet Flask extends the [Tiferet](https://github.com/greatstrength/tiferet) Python framework to build Flask-based APIs using Domain-Driven Design (DDD). It uses [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) as its domain backbone, providing a thin Flask integration layer on top of the shared OpenAPI abstraction.
 
-This tutorial walks you through creating a streamlined calculator API, leveraging Tiferet's robust domain events and configurations while introducing Flask-specific interfaces and endpoints. For a deeper understanding of Tiferet's foundational concepts, consult the [Tiferet documentation](https://github.com/greatstrength/tiferet).
+**Key components:**
+- `FlaskAppBuilder` — assembles a Flask app from `ApiRouter`/`ApiRoute` domain objects.
+- `FlaskApiContext` — extends `OpenApiContext` with Swagger UI support.
+- `FlaskRequestContext` — alias for `OpenApiRequestContext` with Pydantic serialization.
 
-## Getting Started with Tiferet Flask
+## Getting Started
 
-Embark on your Tiferet Flask journey by preparing your development environment. This guide assumes familiarity with Tiferet's core setup.
+### Prerequisites
 
-### Installing Python
+- Python 3.10+
+- A virtual environment (recommended)
 
-Tiferet Flask requires Python 3.10 or later. Follow the detailed [Python installation instructions](https://github.com/greatstrength/tiferet?tab=readme-ov-file#installing-python) in the Tiferet README for your platform (Windows, macOS, or Linux). Verify your installation with:
-
-```bash
-python3.10 --version
-```
-
-### Setting Up a Virtual Environment
-
-Create a dedicated virtual environment named `tiferet_flask_app` to keep dependencies organized:
+### Installation
 
 ```bash
-# Create the Environment
-# Windows
-python -m venv tiferet_flask_app
-
-# macOS/Linux
-python3.10 -m venv tiferet_flask_app
-
-# Activate the Environment
-# Windows (Command Prompt)
-tiferet_flask_app\Scripts\activate
-
-# Windows (PowerShell)
-.\tiferet_flask_app\Scripts\Activate.ps1
-
-# macOS/Linux
-source tiferet_flask_app/bin/activate
+pip install tiferet-flask
 ```
-
-Exit the environment with `deactivate` when finished.
-
-## Your First Calculator API
-
-With your environment ready, install dependencies and configure the project structure to build a dynamic calculator API using Tiferet Flask.
-
-### Installing Tiferet Flask
-
-In your activated virtual environment, install the Tiferet Flask extension using pip:
-
-```bash
-# Windows
-pip install tiferet_flask
-
-# macOS/Linux
-pip3 install tiferet_flask
-```
-
-Note: If developing locally, replace with the appropriate local installation command.
 
 ### Project Structure
 
-Adapt Tiferet's project structure to incorporate Flask, adding a dedicated API script:
-
 ```plaintext
 project_root/
-├── basic_calc.py
-├── calc_cli.py
 ├── calc_flask_api.py
-├── app/
+└── app/
     ├── events/
     │   ├── __init__.py
-    │   ├── calc.py
-    │   └── settings.py
+    │   └── calc.py
     └── configs/
-        ├── __init__.py
         ├── app.yml
+        ├── openapi.yml
         ├── container.yml
         ├── error.yml
-        ├── feature.yml
-        ├── flask.yml
-        └── logging.yml
+        └── feature.yml
 ```
 
-The `app/events/` and `app/configs/` directories align with Tiferet's structure (see [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#project-structure)). The `calc_flask_api.py` script initializes and runs the Flask API, while `flask.yml` defines blueprint and routing configurations.
+## Configuration
 
-## Crafting the Calculator API
+### App Interface (`app/configs/app.yml`)
 
-Extend Tiferet's calculator application into a powerful API by reusing its domain events and configurations, enhanced with Flask-specific functionality.
-
-### Defining Base and Arithmetic Domain Event Classes
-
-Leverage Tiferet's `BasicCalcEvent` (`app/events/settings.py`) for input validation and arithmetic domain events (`AddNumber`, `SubtractNumber`, `MultiplyNumber`, `DivideNumber`, `ExponentiateNumber` in `app/events/calc.py`) for core operations. These remain unchanged from the original calculator app; refer to the [Tiferet README](https://github.com/greatstrength/tiferet?tab=readme-ov-file#defining-base-and-arithmetic-domain-event-classes) for details.
-
-### Configuring the Calculator API
-
-Reuse Tiferet's `container.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-container-in-configscontaineryml)), `error.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-errors-in-configserroryml)), and `feature.yml` ([here](https://github.com/greatstrength/tiferet?tab=readme-ov-file#configuring-the-features-in-configsfeatureyml)) for domain event mappings, error handling, and feature workflows. Introduce a Flask-specific interface in `app.yml` and routing configurations in `flask.yml`.
-
-#### Configuring the App Interface in `configs/app.yml`
-
-Enhance `app/configs/app.yml` with the `calc_flask_api` interface:
+Define the Flask API interface using tiferet-openapi types:
 
 ```yaml
 interfaces:
   calc_flask_api:
-    name: Basic Calculator API
-    description: Perform basic calculator operations via Flask API
+    name: Calculator Flask API
+    description: Arithmetic operations via Flask API
     module_path: tiferet_flask.contexts.flask
     class_name: FlaskApiContext
     attrs:
-      get_blueprints_handler:
-        module_path: tiferet_flask.events.flask
-        class_name: GetFlaskBlueprints
-      get_route_handler:
-        module_path: tiferet_flask.events.flask
-        class_name: GetFlaskRoute
-      get_status_code_handler:
-        module_path: tiferet_flask.events.flask
-        class_name: GetFlaskStatusCode
-      flask_service:
-        module_path: tiferet_flask.repos.flask
-        class_name: FlaskYamlRepository
+      get_routers_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetRouters
+      get_route_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetRoute
+      get_status_code_evt:
+        module_path: tiferet_openapi.events.openapi
+        class_name: GetStatusCode
+      openapi_service:
+        module_path: tiferet_openapi.repos.openapi
+        class_name: OpenApiYamlRepository
         params:
-          flask_config_file: app/configs/flask.yml
+          openapi_yaml_file: app/configs/openapi.yml
 ```
 
-#### Configuring Blueprints, Routes, and Error Status Codes in `configs/flask.yml`
+### OpenAPI Configuration (`app/configs/openapi.yml`)
 
-Define Flask API blueprints, routes, and error mappings in `app/configs/flask.yml`:
+Define routers, routes, and error status codes using the `openapi:` root key:
 
 ```yaml
-flask:
-  blueprints:
+openapi:
+  routers:
     calc:
-      name: calc
-      url_prefix: /calc
+      prefix: /calc
       routes:
         add:
-          rule: /add
+          path: /add
           methods: [POST, GET]
           status_code: 200
         subtract:
-          rule: /subtract
+          path: /subtract
           methods: [POST, GET]
-        multiply:
-          rule: /multiply
-          methods: [POST, GET]
+          status_code: 200
         divide:
-          rule: /divide
+          path: /divide
           methods: [POST, GET]
+          status_code: 200
         sqrt:
-          rule: /sqrt
+          path: /sqrt
           methods: [POST, GET]
+          status_code: 200
   errors:
-    DIVIDE_BY_ZERO: 400 
+    DIVISION_BY_ZERO: 400
+    INVALID_INPUT: 422
 ```
 
-The `url_prefix` ensures all routes are prefixed with `/calc`. Each route’s endpoint (e.g., `calc.add`) aligns with the corresponding feature ID in `feature.yml`. Routes specify a `rule`, supported HTTP `methods`, and a default `status_code` of 200. The `errors` section maps error codes from `error.yml` to HTTP status codes, ensuring proper error handling.
+## Usage
 
-This configuration enables `FlaskApiContext` to orchestrate Flask API operations seamlessly.
-
-### Initializing and Demonstrating the API in calc_flask_api.py
-
-Create `calc_flask_api.py` to initialize the API and define endpoints:
+### Entry Point (`calc_flask_api.py`)
 
 ```python
-# *** imports
+from tiferet_flask import FlaskAppBuilder
 
-from tiferet import App
-from tiferet_flask import FlaskApiContext
+# Create the builder.
+builder = FlaskAppBuilder()
 
-# *** functions
-
-# * functions: view_func
+# Define the view function.
 def view_func(**kwargs):
-    '''
-    Call the view function whenever a route endpoint is invoked.
-
-    The FlaskApiContext instance is accessed via closure (``context``),
-    so it does not need to be passed explicitly as a parameter.
-
-    :param kwargs: Additional keyword arguments.
-    :type kwargs: dict
-    :return: The result of the view function.
-    :rtype: Any
-    '''
-
-    # Get the Flask request context.
     from flask import request, jsonify
 
-    # Format the request data from the json payload (if applicable),
-    # the query parameters, and any route parameters passed via kwargs.
     data = dict(request.json) if request.is_json else {}
     data.update(dict(request.args))
     data.update(kwargs)
-
-    # Format header data from the request headers.
     headers = dict(request.headers)
 
-    # Execute the feature from the request endpoint.
     response, status_code = context.run(
         feature_id=request.endpoint,
         headers=headers,
         data=data,
-        **kwargs,
     )
-
-    # Return the response as JSON.
     return jsonify(response), status_code
 
-# *** exec
+# Build the Flask app with Swagger UI enabled.
+flask_app = builder.run('calc_flask_api', view_func, swagger=True)
 
-# Create the Flask API context.
-context: FlaskApiContext = App().load_interface('calc_flask_api')
+# Access the context for the view function closure.
+context = builder.load_interface('calc_flask_api')
 
-# Build the Flask app.
-context.build_flask_app(view_func=view_func)
-
-# Define the flask_app for external use (e.g., for Flask CLI or WSGI servers).
-def flask_app():
-    '''
-    Create and return the Flask app for testing.
-
-    :return: The Flask app.
-    :rtype: Flask
-    '''
-
-    return context.flask_app
-
-# Run the Flask app if this script is executed directly.
 if __name__ == '__main__':
-    context.flask_app.run(host='127.0.0.1', port=5000, debug=True)
+    flask_app.run(host='127.0.0.1', port=5000, debug=True)
 ```
 
-This script initializes the Tiferet application, loads the `calc_flask_api` interface, and dynamically handles RESTful endpoints for arithmetic operations.
-
-### Demonstrating the Calculator API
-
-Launch the API:
-
-```bash
-python3 calc_flask_api.py
-```
-
-Test endpoints using curl or tools like Postman:
+### Endpoints
 
 ```bash
 # Add two numbers
-curl -X POST http://127.0.0.1:5000/calc/add -H "Content-Type: application/json" -d '{"a": 1, "b": 2}'
+curl -X POST http://127.0.0.1:5000/calc/add \
+  -H "Content-Type: application/json" -d '{"a": 1, "b": 2}'
 # Output: 3
 
-# Calculate square root
-curl -X POST http://127.0.0.1:5000/calc/sqrt -H "Content-Type: application/json" -d '{"a": 16}'
+# Square root
+curl -X POST http://127.0.0.1:5000/calc/sqrt \
+  -H "Content-Type: application/json" -d '{"a": 16}'
 # Output: 4.0
 
 # Division by zero
-curl -X POST http://127.0.0.1:5000/calc/divide -H "Content-Type: application/json" -d '{"a": 5, "b": 0}'
-# Output: {"error_code": "DIVIDE_BY_ZERO", "text": "Cannot divide by zero"}
+curl -X POST http://127.0.0.1:5000/calc/divide \
+  -H "Content-Type: application/json" -d '{"a": 5, "b": 0}'
+# Output: {"error_code": "DIVISION_BY_ZERO", ...}
 ```
 
-## Conclusion
+### Swagger UI
 
-Tiferet Flask empowers developers to craft elegant, modular Flask APIs within Tiferet's DDD framework, as showcased in this calculator tutorial. By seamlessly reusing Tiferet's domain events and configurations and introducing a Flask interface, you've built a scalable, intuitive API with minimal effort. Expand its capabilities by integrating authentication, advanced features like trigonometric operations, or combining with Tiferet's CLI or TUI contexts. Dive into the [Tiferet documentation](https://github.com/greatstrength/tiferet) for advanced DDD techniques, and experiment with `app/configs/` to customize your API, transforming complex web applications—whether monolithic or networked—into clear, purposeful solutions.
+When `swagger=True` is passed to `builder.run()`, Swagger UI is available at:
+- **Swagger UI:** `http://127.0.0.1:5000/docs`
+- **OpenAPI spec:** `http://127.0.0.1:5000/docs/openapi.json`
+
+## Architecture
+
+Tiferet Flask v0.4.0 delegates all domain, interface, event, mapper, and repository concerns to `tiferet-openapi`. Only two packages remain under `tiferet_flask/`:
+
+- **`builders/`** — `FlaskAppBuilder` consumes `ApiRouter`/`ApiRoute` from tiferet-openapi, maps them to Flask Blueprints, and optionally registers a Swagger UI blueprint.
+- **`contexts/`** — `FlaskApiContext` is a thin subclass of `OpenApiContext` that adds `create_swagger_blueprint()`. `FlaskRequestContext` is an alias for `OpenApiRequestContext`.
+
+For domain-level documentation (domain objects, events, mappers, repositories), see [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi).
+
+## Example
+
+See the [`example/`](example/) directory for a complete calculator Flask API demonstrating the v0.4.0 architecture with Swagger support.
+
+## License
+
+MIT

--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -14,4 +14,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Summary

Final packaging cleanup for the v0.4.0 milestone.

### Changes
- **Version:** Bumped `__version__` to `"0.4.0"`.
- **Exports:** Already correct from #45 — only Flask-specific components (`FlaskAppBuilder`, `FlaskApp`, `FlaskApiContext`, `FlaskRequestContext`).
- **README.md:** Complete rewrite documenting the v0.4.0 architecture — tiferet-openapi as domain backbone, `openapi:` YAML config format, `FlaskAppBuilder` with `swagger=True`, updated project structure and code examples.
- **AGENTS.md:** Complete rewrite documenting v0.4.0 package layout (only `builders/` and `contexts/`), dependency on `tiferet-openapi>=0.1.1`, migration guide from v0.3.x.
- **pyproject.toml:** Verified correct (no changes needed — already updated in prior issues).

### Verification
- `pip install -e .` installs as `tiferet-flask-0.4.0`.
- All 4 top-level imports work cleanly.

Closes #49

---
[Warp conversation](https://app.warp.dev/conversation/a1f7a3e1-ed18-4a39-b0bc-af1dd660b26e)

Co-Authored-By: Oz <oz-agent@warp.dev>