### PR TITLE
Packaging – Dependencies, Version Bump, and Documentation (#57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Tiferet Flask (v0.4.0)
+# AGENTS.md — Tiferet Flask (v0.5.0)
 
 ## Project Overview
 
-**Tiferet Flask** is a Flask extension for the Tiferet framework, providing Flask-specific API building and Swagger UI support on top of the shared [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) abstraction layer. All domain objects, service interfaces, domain events, mappers, and repositories are provided by `tiferet-openapi`.
+**Tiferet Flask** is a Flask extension for the Tiferet framework, providing Flask-specific API assembly and Swagger UI support on top of the shared [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) abstraction layer. All domain objects, service interfaces, domain events, mappers, and repositories are provided by `tiferet-openapi`.
 
 - **Repository:** https://github.com/greatstrength/tiferet-flask
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.4.0`
-- **Dependencies:** `tiferet >= 2.0.0b1`, `tiferet-openapi >= 0.1.1`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
+- **Version:** `0.5.0`
+- **Dependencies:** `tiferet-openapi >= 0.1.3`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
 
 ## Architecture
 
@@ -16,8 +16,8 @@
 
 ```
 tiferet_flask/
-├── __init__.py          — Version (0.4.0) and public exports
-├── builders/            — FlaskAppBuilder (AppBuilder) with swagger support
+├── __init__.py          — Version (0.5.0) and public exports
+├── blueprints/          — Stateless blueprint functions (build_flask_app, build_blueprint, get_routers, run)
 └── contexts/            — FlaskApiContext (OpenApiContext), FlaskRequestContext (alias)
 ```
 
@@ -25,7 +25,7 @@ All domain, interface, event, mapper, and repository layers are provided by `tif
 
 ### Key Concepts
 
-- **FlaskAppBuilder** (`builders/flask.py`): Extends `tiferet.builders.AppBuilder`. Consumes `ApiRouter`/`ApiRoute` from `tiferet_openapi`. Methods: `get_routers()`, `build_blueprint(router, view_func)`, `build_flask_app(interface_id, view_func, swagger=False)`, `run()`. Exported as `FlaskApp` alias.
+- **Blueprint functions** (`blueprints/flask.py`): Stateless functions that consume `ApiRouter`/`ApiRoute` from `tiferet_openapi`. Functions: `get_routers(service_provider)`, `build_blueprint(router, view_func)`, `build_flask_app(interface_id, view_func, swagger=False)`, `run(interface_id, view_func)`. `build_flask_app` is exported as the `FlaskApp` alias.
 - **FlaskApiContext** (`contexts/flask.py`): Thin subclass of `tiferet_openapi.OpenApiContext`. Inherits `parse_request()`, `handle_error()`, `handle_response()`, `generate_spec()`, `get_routers_handler`. Adds `create_swagger_blueprint(title, version, description)` and overrides `create_docs_handler()` to delegate to it.
 - **FlaskRequestContext** (`contexts/request.py`): Alias for `tiferet_openapi.OpenApiRequestContext`. Provides Pydantic `BaseModel.model_dump()` serialization for responses.
 
@@ -39,10 +39,12 @@ All domain, interface, event, mapper, and repository layers are provided by `tif
 
 ### Runtime Flow
 
-1. `FlaskAppBuilder()` loads settings and service provider.
-2. `builder.run(interface_id, view_func, swagger=True)` loads the interface, assembles Flask Blueprints from `ApiRouter` objects, optionally registers the Swagger UI blueprint, and returns a Flask app.
-3. `FlaskApiContext` (via `OpenApiContext`) handles request parsing, feature execution, error handling with status codes, and response formatting.
-4. On request, `view_func` calls `context.run()` → parses request → executes feature → returns `(response, status_code)`.
+1. `FlaskApp(interface_id, view_func, swagger=True)` (alias for `build_flask_app`) resolves the interface definition via `tiferet.blueprints.main`.
+2. Builds a service provider, realizes the interface context, creates a Flask app with CORS.
+3. Loads `ApiRouter` objects via `get_routers()`, maps each to a Flask `Blueprint` via `build_blueprint()`, and registers them.
+4. Optionally registers the Swagger UI blueprint via `interface_context.create_swagger_blueprint()`.
+5. `FlaskApiContext` (via `OpenApiContext`) handles request parsing, feature execution, error handling with status codes, and response formatting.
+6. On request, `view_func` calls `context.run()` → parses request → executes feature → returns `(response, status_code)`.
 
 ### YAML Configuration
 
@@ -69,7 +71,7 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 ## Testing
 
 - **Framework:** `pytest`
-- **Test location:** Co-located in `contexts/tests/`.
+- **Test location:** Co-located in `contexts/tests/` and `blueprints/tests/`.
 - **Run tests:** `pytest tiferet_flask/ -v`
 - **Patterns:**
   - Context tests use `mock.Mock(spec=DomainEvent)` for event dependencies and `ApiRoute`/`ApiRouter` from `tiferet_openapi`.
@@ -78,15 +80,22 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 ## Key Files
 
 - `tiferet_flask/__init__.py` — Version and public exports
-- `tiferet_flask/builders/flask.py` — FlaskAppBuilder
+- `tiferet_flask/blueprints/flask.py` — Blueprint functions (build_flask_app, build_blueprint, get_routers, run)
 - `tiferet_flask/contexts/flask.py` — FlaskApiContext (OpenApiContext subclass with Swagger)
 - `tiferet_flask/contexts/request.py` — FlaskRequestContext (alias for OpenApiRequestContext)
+
+## Migration from v0.4.x
+
+- **Builders → Blueprints:** The `FlaskAppBuilder` class has been replaced by stateless blueprint functions in `blueprints/flask.py`. `FlaskAppBuilder()` → `build_flask_app()` / `FlaskApp()`. No more class instantiation.
+- **Imports:** `from tiferet_flask import FlaskAppBuilder` → `from tiferet_flask import FlaskApp` (or `build_flask_app`).
+- **Usage:** `builder = FlaskAppBuilder(); builder.run(...)` → `flask_app = FlaskApp(interface_id, view_func, swagger=True)`.
+- **Dependencies:** The direct `tiferet>=2.0.0b1` dependency has been removed. Tiferet is now provided transitively through `tiferet-openapi>=0.1.3`.
+- **Package layout:** `builders/` → `blueprints/`.
 
 ## Migration from v0.3.x
 
 - **Deleted packages:** `domain/`, `interfaces/`, `events/`, `mappers/`, `repos/` — all replaced by `tiferet-openapi>=0.1.1`.
 - **Contexts:** `FlaskApiContext` now extends `OpenApiContext` (not `AppInterfaceContext`). Constructor requires `get_routers_evt` in addition to `get_route_evt` and `get_status_code_evt`. `FlaskRequestContext` is now an alias for `OpenApiRequestContext`.
-- **Builders:** `get_blueprints()` → `get_routers()`. `build_blueprint()` accepts `ApiRouter` (not `FlaskBlueprint`). `build_flask_app()` accepts `swagger=True`.
 - **Configuration:** `flask:` root key → `openapi:` root key. `blueprints` → `routers`. `url_prefix` → `prefix`. `rule` → `path`. `flask_config_file` → `openapi_yaml_file`.
 - **Imports:** Domain types (`FlaskRoute`, `FlaskBlueprint`, etc.) no longer exported from `tiferet_flask`. Import `ApiRoute`, `ApiRouter`, etc. from `tiferet_openapi`.
 - **Dependency:** Added `tiferet-openapi>=0.1.1`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Tiferet Flask extends the [Tiferet](https://github.com/greatstrength/tiferet) Python framework to build Flask-based APIs using Domain-Driven Design (DDD). It uses [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi) as its domain backbone, providing a thin Flask integration layer on top of the shared OpenAPI abstraction.
 
 **Key components:**
-- `FlaskAppBuilder` — assembles a Flask app from `ApiRouter`/`ApiRoute` domain objects.
+- `build_flask_app` / `FlaskApp` — assembles a Flask app from `ApiRouter`/`ApiRoute` domain objects using blueprint functions.
 - `FlaskApiContext` — extends `OpenApiContext` with Swagger UI support.
 - `FlaskRequestContext` — alias for `OpenApiRequestContext` with Pydantic serialization.
 
@@ -21,6 +21,8 @@ Tiferet Flask extends the [Tiferet](https://github.com/greatstrength/tiferet) Py
 ```bash
 pip install tiferet-flask
 ```
+
+This installs `tiferet-openapi` (which transitively provides `tiferet`) along with Flask and Flask-CORS.
 
 ### Project Structure
 
@@ -105,10 +107,7 @@ openapi:
 ### Entry Point (`calc_flask_api.py`)
 
 ```python
-from tiferet_flask import FlaskAppBuilder
-
-# Create the builder.
-builder = FlaskAppBuilder()
+from tiferet_flask import FlaskApp
 
 # Define the view function.
 def view_func(**kwargs):
@@ -127,10 +126,7 @@ def view_func(**kwargs):
     return jsonify(response), status_code
 
 # Build the Flask app with Swagger UI enabled.
-flask_app = builder.run('calc_flask_api', view_func, swagger=True)
-
-# Access the context for the view function closure.
-context = builder.load_interface('calc_flask_api')
+flask_app = FlaskApp('calc_flask_api', view_func, swagger=True)
 
 if __name__ == '__main__':
     flask_app.run(host='127.0.0.1', port=5000, debug=True)
@@ -157,22 +153,29 @@ curl -X POST http://127.0.0.1:5000/calc/divide \
 
 ### Swagger UI
 
-When `swagger=True` is passed to `builder.run()`, Swagger UI is available at:
+When `swagger=True` is passed to `FlaskApp()`, Swagger UI is available at:
 - **Swagger UI:** `http://127.0.0.1:5000/docs`
 - **OpenAPI spec:** `http://127.0.0.1:5000/docs/openapi.json`
 
 ## Architecture
 
-Tiferet Flask v0.4.0 delegates all domain, interface, event, mapper, and repository concerns to `tiferet-openapi`. Only two packages remain under `tiferet_flask/`:
+Tiferet Flask v0.5.0 delegates all domain, interface, event, mapper, and repository concerns to `tiferet-openapi`. Only two packages remain under `tiferet_flask/`:
 
-- **`builders/`** — `FlaskAppBuilder` consumes `ApiRouter`/`ApiRoute` from tiferet-openapi, maps them to Flask Blueprints, and optionally registers a Swagger UI blueprint.
+- **`blueprints/`** — Stateless blueprint functions (`build_flask_app`, `build_blueprint`, `get_routers`, `run`) that consume `ApiRouter`/`ApiRoute` from tiferet-openapi, map them to Flask Blueprints, and optionally register a Swagger UI blueprint. Exported as `FlaskApp` alias.
 - **`contexts/`** — `FlaskApiContext` is a thin subclass of `OpenApiContext` that adds `create_swagger_blueprint()`. `FlaskRequestContext` is an alias for `OpenApiRequestContext`.
 
 For domain-level documentation (domain objects, events, mappers, repositories), see [tiferet-openapi](https://github.com/greatstrength/tiferet-openapi).
 
+## Migration from v0.4.x
+
+- **Builders → Blueprints:** The `FlaskAppBuilder` class has been replaced by stateless blueprint functions. `FlaskAppBuilder()` → `build_flask_app()` / `FlaskApp()`. No more class instantiation — call the function directly.
+- **Imports:** `from tiferet_flask import FlaskAppBuilder` → `from tiferet_flask import FlaskApp` (or `build_flask_app`).
+- **Usage:** `builder = FlaskAppBuilder(); builder.run(...)` → `flask_app = FlaskApp(interface_id, view_func, swagger=True)`.
+- **Dependencies:** The direct `tiferet>=2.0.0b1` dependency has been removed. Tiferet is now provided transitively through `tiferet-openapi>=0.1.3`.
+
 ## Example
 
-See the [`example/`](example/) directory for a complete calculator Flask API demonstrating the v0.4.0 architecture with Swagger support.
+See the [`example/`](example/) directory for a complete calculator Flask API demonstrating the v0.5.0 architecture with Swagger support.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet>=2.0.0b1",
-    "tiferet-openapi>=0.1.1",
+    "tiferet-openapi>=0.1.3",
     "flask>=3.1.2",
     "flask_cors>=6.0.1"
 ]

--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -14,4 +14,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

Updates package dependencies, version, and documentation to reflect the v0.5.0 blueprint architecture.

Closes #57

## Changes

- **pyproject.toml**: Removed direct `tiferet>=2.0.0b1` dependency; updated `tiferet-openapi` to `>=0.1.3`.
- **tiferet_flask/__init__.py**: Bumped version to `0.5.0`.
- **README.md**: Replaced `FlaskAppBuilder` usage with `FlaskApp`/`build_flask_app` blueprint functions, updated architecture section, added "Migration from v0.4.x" section.
- **AGENTS.md**: Updated version, dependencies, package layout, key concepts, runtime flow, key files, test locations, and added "Migration from v0.4.x" section.

---

[Conversation link](https://app.warp.dev/conversation/83da75ff-f05d-4623-9abb-146523e0bca4)

Co-Authored-By: Oz <oz-agent@warp.dev>