### PR TITLE
v1.0.0b1 – Blueprint functions, tiferet-openapi 1.0.0b1, example update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Tiferet Flask (v0.5.0)
+# AGENTS.md — Tiferet Flask (v1.0.0b1)
 
 ## Project Overview
 
@@ -7,8 +7,8 @@
 - **Repository:** https://github.com/greatstrength/tiferet-flask
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.5.0`
-- **Dependencies:** `tiferet-openapi >= 0.1.3`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
+- **Version:** `1.0.0b1`
+- **Dependencies:** `tiferet-openapi >= 1.0.0b1`, `flask >= 3.1.2`, `flask_cors >= 6.0.1`
 
 ## Architecture
 
@@ -16,7 +16,7 @@
 
 ```
 tiferet_flask/
-├── __init__.py          — Version (0.5.0) and public exports
+├── __init__.py          — Version (1.0.0b1) and public exports
 ├── blueprints/          — Stateless blueprint functions (build_flask_app, build_blueprint, get_routers, run)
 └── contexts/            — FlaskApiContext (OpenApiContext), FlaskRequestContext (alias)
 ```
@@ -25,7 +25,7 @@ All domain, interface, event, mapper, and repository layers are provided by `tif
 
 ### Key Concepts
 
-- **Blueprint functions** (`blueprints/flask.py`): Stateless functions that consume `ApiRouter`/`ApiRoute` from `tiferet_openapi`. Functions: `get_routers(service_provider)`, `build_blueprint(router, view_func)`, `build_flask_app(interface_id, view_func, swagger=False)`, `run(interface_id, view_func)`. `build_flask_app` is exported as the `FlaskApp` alias.
+- **Blueprint functions** (`blueprints/flask.py`): Stateless functions that consume `ApiRouter`/`ApiRoute` from `tiferet_openapi`. Functions: `get_routers(interface_context)`, `build_blueprint(router, view_func)`, `build_flask_app(interface_id, view_func, swagger=False, **parameters)`, `run(interface_id, view_func)`. `build_flask_app` is exported as the `FlaskApp` alias. The `**parameters` are forwarded to `resolve_interface` (e.g., `app_yaml_file`).
 - **FlaskApiContext** (`contexts/flask.py`): Thin subclass of `tiferet_openapi.OpenApiContext`. Inherits `parse_request()`, `handle_error()`, `handle_response()`, `generate_spec()`, `get_routers_handler`. Adds `create_swagger_blueprint(title, version, description)` and overrides `create_docs_handler()` to delegate to it.
 - **FlaskRequestContext** (`contexts/request.py`): Alias for `tiferet_openapi.OpenApiRequestContext`. Provides Pydantic `BaseModel.model_dump()` serialization for responses.
 
@@ -39,12 +39,13 @@ All domain, interface, event, mapper, and repository layers are provided by `tif
 
 ### Runtime Flow
 
-1. `FlaskApp(interface_id, view_func, swagger=True)` (alias for `build_flask_app`) resolves the interface definition via `tiferet.blueprints.main`.
-2. Builds a service provider, realizes the interface context, creates a Flask app with CORS.
-3. Loads `ApiRouter` objects via `get_routers()`, maps each to a Flask `Blueprint` via `build_blueprint()`, and registers them.
+1. `FlaskApp(interface_id, view_func, swagger=True, app_yaml_file='app/configs/app.yml')` (alias for `build_flask_app`) resolves the interface definition via `tiferet.blueprints.main.resolve_interface`.
+2. Realizes the interface context via `realize_interface`, creates a Flask app with CORS.
+3. Loads `ApiRouter` objects via `interface_context.get_routers_handler()`, maps each to a Flask `Blueprint` via `build_blueprint()`, and registers them.
 4. Optionally registers the Swagger UI blueprint via `interface_context.create_swagger_blueprint()`.
 5. `FlaskApiContext` (via `OpenApiContext`) handles request parsing, feature execution, error handling with status codes, and response formatting.
 6. On request, `view_func` calls `context.run()` → parses request → executes feature → returns `(response, status_code)`.
+7. The `context` is obtained separately via `resolve_interface()` + `realize_interface()` for use in the view function closure.
 
 ### YAML Configuration
 
@@ -84,12 +85,36 @@ All code follows tiferet v2 artifact comment conventions (`# ***`, `# **`, `# *`
 - `tiferet_flask/contexts/flask.py` — FlaskApiContext (OpenApiContext subclass with Swagger)
 - `tiferet_flask/contexts/request.py` — FlaskRequestContext (alias for OpenApiRequestContext)
 
+### App YAML Configuration Ordering
+
+The `app.yml` `attrs` section must list dependencies **before** the services that consume them, because the DI container wires factories eagerly in registration order. Place `openapi_service` (with its `params`) before the event attrs that depend on it:
+
+```yaml
+attrs:
+  openapi_service:        # registered first — events depend on it
+    module_path: tiferet_openapi.repos.openapi
+    class_name: OpenApiYamlRepository
+    params:
+      openapi_yaml_file: app/configs/openapi.yml
+  get_routers_evt:        # registered after openapi_service
+    module_path: tiferet_openapi.events.openapi
+    class_name: GetRouters
+  get_route_evt:
+    module_path: tiferet_openapi.events.openapi
+    class_name: GetRoute
+  get_status_code_evt:
+    module_path: tiferet_openapi.events.openapi
+    class_name: GetStatusCode
+```
+
 ## Migration from v0.4.x
 
 - **Builders → Blueprints:** The `FlaskAppBuilder` class has been replaced by stateless blueprint functions in `blueprints/flask.py`. `FlaskAppBuilder()` → `build_flask_app()` / `FlaskApp()`. No more class instantiation.
 - **Imports:** `from tiferet_flask import FlaskAppBuilder` → `from tiferet_flask import FlaskApp` (or `build_flask_app`).
-- **Usage:** `builder = FlaskAppBuilder(); builder.run(...)` → `flask_app = FlaskApp(interface_id, view_func, swagger=True)`.
-- **Dependencies:** The direct `tiferet>=2.0.0b1` dependency has been removed. Tiferet is now provided transitively through `tiferet-openapi>=0.1.3`.
+- **Usage:** `builder = FlaskAppBuilder(); builder.run(...)` → `flask_app = FlaskApp(interface_id, view_func, swagger=True, app_yaml_file='app/configs/app.yml')`.
+- **Context access:** `builder.load_interface(id)` → `resolve_interface(id, app_yaml_file=...)` + `realize_interface(app_interface, id)`.
+- **get_routers:** Now takes the realized `interface_context` instead of a `ServiceProvider`.
+- **Dependencies:** `tiferet-openapi>=0.1.3` → `tiferet-openapi>=1.0.0b1`. Tiferet is provided transitively.
 - **Package layout:** `builders/` → `blueprints/`.
 
 ## Migration from v0.3.x

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Calculator Flask API Example
 
-A self-contained calculator API demonstrating the Tiferet Flask v0.4.0 architecture with Swagger UI support.
+A self-contained calculator API demonstrating the Tiferet Flask v0.5.0 architecture with Swagger UI support.
 
 ## Prerequisites
 

--- a/example/app/configs/app.yml
+++ b/example/app/configs/app.yml
@@ -5,6 +5,11 @@ interfaces:
     module_path: tiferet_flask.contexts.flask
     class_name: FlaskApiContext
     attrs:
+      openapi_service:
+        module_path: tiferet_openapi.repos.openapi
+        class_name: OpenApiYamlRepository
+        params:
+          openapi_yaml_file: app/configs/openapi.yml
       get_routers_evt:
         module_path: tiferet_openapi.events.openapi
         class_name: GetRouters
@@ -14,8 +19,3 @@ interfaces:
       get_status_code_evt:
         module_path: tiferet_openapi.events.openapi
         class_name: GetStatusCode
-      openapi_service:
-        module_path: tiferet_openapi.repos.openapi
-        class_name: OpenApiYamlRepository
-        params:
-          openapi_yaml_file: app/configs/openapi.yml

--- a/example/calc_flask_api.py
+++ b/example/calc_flask_api.py
@@ -3,7 +3,8 @@
 # *** imports
 
 # ** infra
-from tiferet_flask import FlaskAppBuilder
+from tiferet_flask import FlaskApp
+from tiferet.blueprints.main import resolve_interface, realize_interface
 
 
 # *** functions
@@ -43,14 +44,12 @@ def view_func(**kwargs):
 
 # *** exec
 
-# Create the builder.
-builder = FlaskAppBuilder()
-
 # Build the Flask app with Swagger UI enabled.
-flask_app = builder.run('calc_flask_api', view_func, swagger=True)
+flask_app = FlaskApp('calc_flask_api', view_func, swagger=True, app_yaml_file='app/configs/app.yml')
 
-# Access the context for the view function closure.
-context = builder.load_interface('calc_flask_api')
+# Load the interface context for the view function closure.
+app_interface, _ = resolve_interface('calc_flask_api', app_yaml_file='app/configs/app.yml')
+context = realize_interface(app_interface, 'calc_flask_api')
 
 # Run the Flask app if executed directly.
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet-openapi>=0.1.3",
+    "tiferet-openapi>=1.0.0b1",
     "flask>=3.1.2",
     "flask_cors>=6.0.1"
 ]

--- a/tiferet_flask/__init__.py
+++ b/tiferet_flask/__init__.py
@@ -14,4 +14,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.5.0"
+__version__ = "1.0.0b1"

--- a/tiferet_flask/blueprints/flask.py
+++ b/tiferet_flask/blueprints/flask.py
@@ -8,31 +8,28 @@ from typing import Callable, List
 # ** infra
 from flask import Flask, Blueprint
 from flask_cors import CORS
-from tiferet.di import ServiceProvider
 from tiferet_openapi import ApiRouter
 from tiferet.blueprints.main import (
     resolve_interface,
     realize_interface,
-    create_service_provider,
 )
 
 
 # *** blueprints
 
 # ** blueprint: get_routers
-def get_routers(service_provider: ServiceProvider) -> List[ApiRouter]:
+def get_routers(interface_context) -> List[ApiRouter]:
     '''
-    Resolve and execute the get_routers event from the service provider.
+    Execute the get_routers event from the interface context.
 
-    :param service_provider: The service provider to resolve events from.
-    :type service_provider: ServiceProvider
+    :param interface_context: The realized interface context with a get_routers_evt attribute.
+    :type interface_context: AppInterfaceContext
     :return: A list of ApiRouter domain objects.
     :rtype: List[ApiRouter]
     '''
 
-    # Resolve the get_routers event and execute it.
-    get_routers_evt = service_provider.get_service('get_routers_evt')
-    return get_routers_evt.execute()
+    # Execute the get_routers handler from the interface context.
+    return interface_context.get_routers_handler()
 
 
 # ** blueprint: build_blueprint
@@ -91,12 +88,7 @@ def build_flask_app(interface_id: str, view_func: Callable, swagger: bool = Fals
     '''
 
     # Resolve the interface definition.
-    app_interface, default_services = resolve_interface(interface_id, **parameters)
-
-    # Build a service provider seeded with default service dependencies.
-    service_provider = create_service_provider(
-        type_map={dep.service_id: dep.get_service_type() for dep in default_services},
-    )
+    app_interface, _ = resolve_interface(interface_id, **parameters)
 
     # Realize the app interface context.
     interface_context = realize_interface(app_interface, interface_id)
@@ -106,14 +98,14 @@ def build_flask_app(interface_id: str, view_func: Callable, swagger: bool = Fals
     CORS(flask_app)
 
     # Load and register routers as blueprints.
-    routers = get_routers(service_provider)
+    routers = get_routers(interface_context)
     for router in routers:
         blueprint = build_blueprint(router, view_func=view_func)
         flask_app.register_blueprint(blueprint)
 
     # Optionally register the swagger blueprint.
     if swagger and hasattr(interface_context, 'create_swagger_blueprint'):
-        swagger_bp = interface_context.create_swagger_blueprint(**parameters)
+        swagger_bp = interface_context.create_swagger_blueprint()
         flask_app.register_blueprint(swagger_bp)
 
     # Return the assembled Flask application.

--- a/tiferet_flask/blueprints/tests/test_flask.py
+++ b/tiferet_flask/blueprints/tests/test_flask.py
@@ -3,13 +3,12 @@
 # ** infra
 import pytest
 from unittest import mock
-from flask import Blueprint
+from flask import Flask, Blueprint
 from tiferet.events import DomainEvent
-from tiferet.di import ServiceProvider
 from tiferet_openapi import ApiRoute, ApiRouter
 
 # ** app
-from ..flask import get_routers, build_blueprint
+from ..flask import get_routers, build_blueprint, build_flask_app
 
 
 # *** fixtures
@@ -69,25 +68,25 @@ def mock_view_func() -> mock.Mock:
     Fixture to provide a mock view function.
     '''
 
-    return mock.Mock()
+    # Create a mock with required_methods set for Flask add_url_rule compatibility.
+    view_func = mock.Mock()
+    view_func.required_methods = set()
+
+    return view_func
 
 
-# ** fixture: mock_service_provider
+# ** fixture: mock_interface_context
 @pytest.fixture
-def mock_service_provider(sample_router: ApiRouter) -> mock.Mock:
+def mock_interface_context(sample_router: ApiRouter) -> mock.Mock:
     '''
-    Fixture to provide a mock ServiceProvider with get_routers_evt.
+    Fixture to provide a mock interface context with a get_routers_handler.
     '''
 
-    # Create a mock get_routers event.
-    mock_get_routers_evt = mock.Mock(spec=DomainEvent)
-    mock_get_routers_evt.execute = mock.Mock(return_value=[sample_router])
+    # Create the mock interface context.
+    context = mock.Mock()
+    context.get_routers_handler = mock.Mock(return_value=[sample_router])
 
-    # Create the mock service provider.
-    provider = mock.Mock(spec=ServiceProvider)
-    provider.get_service = mock.Mock(return_value=mock_get_routers_evt)
-
-    return provider
+    return context
 
 
 # *** tests
@@ -151,17 +150,143 @@ def test_build_blueprint_no_prefix(mock_view_func: mock.Mock):
 
 
 # ** test: get_routers
-def test_get_routers(mock_service_provider: mock.Mock, sample_router: ApiRouter):
+def test_get_routers(mock_interface_context: mock.Mock, sample_router: ApiRouter):
     '''
-    Test get_routers resolves and executes the get_routers event.
+    Test get_routers executes the get_routers_handler on the interface context.
     '''
 
     # Get the routers.
-    routers = get_routers(mock_service_provider)
+    routers = get_routers(mock_interface_context)
 
-    # Assert the service provider was called correctly.
-    mock_service_provider.get_service.assert_called_once_with('get_routers_evt')
+    # Assert the handler was called.
+    mock_interface_context.get_routers_handler.assert_called_once()
 
     # Assert the result contains the expected router.
     assert len(routers) == 1
     assert routers[0] is sample_router
+
+
+# ** test: get_routers_empty
+def test_get_routers_empty():
+    '''
+    Test get_routers returns an empty list when no routers are configured.
+    '''
+
+    # Create a context with no routers.
+    context = mock.Mock()
+    context.get_routers_handler = mock.Mock(return_value=[])
+
+    # Get the routers.
+    routers = get_routers(context)
+
+    # Assert the result is empty.
+    assert routers == []
+
+
+# ** test: build_flask_app_registers_blueprints
+def test_build_flask_app_registers_blueprints(sample_router: ApiRouter, mock_view_func: mock.Mock):
+    '''
+    Test build_flask_app creates a Flask app with registered blueprints.
+    '''
+
+    # Mock resolve_interface and realize_interface.
+    mock_app_interface = mock.Mock()
+    mock_context = mock.Mock()
+    mock_context.get_routers_handler = mock.Mock(return_value=[sample_router])
+
+    with mock.patch('tiferet_flask.blueprints.flask.resolve_interface', return_value=(mock_app_interface, [])) as mock_resolve, \
+         mock.patch('tiferet_flask.blueprints.flask.realize_interface', return_value=mock_context) as mock_realize:
+
+        # Build the Flask app.
+        flask_app = build_flask_app('test_interface', mock_view_func, app_yaml_file='app.yml')
+
+    # Assert a Flask app was returned.
+    assert isinstance(flask_app, Flask)
+
+    # Assert resolve_interface was called with correct params.
+    mock_resolve.assert_called_once_with('test_interface', app_yaml_file='app.yml')
+
+    # Assert realize_interface was called with the resolved interface.
+    mock_realize.assert_called_once_with(mock_app_interface, 'test_interface')
+
+    # Assert routers were loaded from the context.
+    mock_context.get_routers_handler.assert_called_once()
+
+
+# ** test: build_flask_app_with_swagger
+def test_build_flask_app_with_swagger(mock_view_func: mock.Mock):
+    '''
+    Test build_flask_app registers a Swagger blueprint when swagger=True.
+    '''
+
+    # Mock resolve_interface and realize_interface.
+    mock_app_interface = mock.Mock()
+    mock_swagger_bp = Blueprint('swagger', __name__, url_prefix='/docs')
+    mock_context = mock.Mock()
+    mock_context.get_routers_handler = mock.Mock(return_value=[])
+    mock_context.create_swagger_blueprint = mock.Mock(return_value=mock_swagger_bp)
+
+    with mock.patch('tiferet_flask.blueprints.flask.resolve_interface', return_value=(mock_app_interface, [])), \
+         mock.patch('tiferet_flask.blueprints.flask.realize_interface', return_value=mock_context):
+
+        # Build the Flask app with swagger enabled.
+        flask_app = build_flask_app('test_interface', mock_view_func, swagger=True, app_yaml_file='app.yml')
+
+    # Assert create_swagger_blueprint was called.
+    mock_context.create_swagger_blueprint.assert_called_once()
+
+    # Assert the swagger blueprint was registered.
+    assert 'swagger' in flask_app.blueprints
+
+
+# ** test: build_flask_app_without_swagger
+def test_build_flask_app_without_swagger(mock_view_func: mock.Mock):
+    '''
+    Test build_flask_app does not register Swagger when swagger=False.
+    '''
+
+    # Mock resolve_interface and realize_interface.
+    mock_app_interface = mock.Mock()
+    mock_context = mock.Mock()
+    mock_context.get_routers_handler = mock.Mock(return_value=[])
+    mock_context.create_swagger_blueprint = mock.Mock()
+
+    with mock.patch('tiferet_flask.blueprints.flask.resolve_interface', return_value=(mock_app_interface, [])), \
+         mock.patch('tiferet_flask.blueprints.flask.realize_interface', return_value=mock_context):
+
+        # Build the Flask app without swagger.
+        flask_app = build_flask_app('test_interface', mock_view_func, swagger=False, app_yaml_file='app.yml')
+
+    # Assert create_swagger_blueprint was NOT called.
+    mock_context.create_swagger_blueprint.assert_not_called()
+
+    # Assert no swagger blueprint was registered.
+    assert 'swagger' not in flask_app.blueprints
+
+
+# ** test: build_flask_app_does_not_leak_params_to_swagger
+def test_build_flask_app_does_not_leak_params_to_swagger(mock_view_func: mock.Mock):
+    '''
+    Test build_flask_app does not pass resolve_interface params to create_swagger_blueprint.
+    '''
+
+    # Mock resolve_interface and realize_interface.
+    mock_app_interface = mock.Mock()
+    mock_swagger_bp = Blueprint('swagger', __name__, url_prefix='/docs')
+    mock_context = mock.Mock()
+    mock_context.get_routers_handler = mock.Mock(return_value=[])
+    mock_context.create_swagger_blueprint = mock.Mock(return_value=mock_swagger_bp)
+
+    with mock.patch('tiferet_flask.blueprints.flask.resolve_interface', return_value=(mock_app_interface, [])), \
+         mock.patch('tiferet_flask.blueprints.flask.realize_interface', return_value=mock_context):
+
+        # Build the Flask app with extra parameters.
+        flask_app = build_flask_app(
+            'test_interface', mock_view_func,
+            swagger=True,
+            app_yaml_file='app.yml',
+            extra_param='should_not_leak',
+        )
+
+    # Assert create_swagger_blueprint was called with no arguments.
+    mock_context.create_swagger_blueprint.assert_called_once_with()


### PR DESCRIPTION
## Summary

Upgrades tiferet-flask to v1.0.0b1, targeting `tiferet-openapi>=1.0.0b1` and refactoring the blueprint layer for the new DI and interface resolution pattern.

## Changes

### Blueprints (`tiferet_flask/blueprints/flask.py`)
- `build_flask_app` now uses `realize_interface` context for router loading instead of a separate `ServiceProvider`
- `get_routers` accepts the realized `interface_context` (calls `get_routers_handler()`) instead of a `ServiceProvider`
- Fixed parameter leak from `resolve_interface` kwargs into `create_swagger_blueprint()`
- Removed unused `ServiceProvider` and `create_service_provider` imports

### Example (`example/`)
- Updated `calc_flask_api.py` to use `FlaskApp` + `resolve_interface`/`realize_interface` (replaces `FlaskAppBuilder`)
- Added `app_yaml_file` parameter for explicit config path
- Reordered `app.yml` attrs: `openapi_service` before events for DI wiring
- Bumped README version reference to v0.5.0

### Tests
- Rewrote `get_routers` test for new `interface_context` pattern
- Added: `test_get_routers_empty`, `test_build_flask_app_registers_blueprints`, `test_build_flask_app_with_swagger`, `test_build_flask_app_without_swagger`, `test_build_flask_app_does_not_leak_params_to_swagger`
- 25/25 tests passing

### Packaging & Docs
- Bumped `tiferet-openapi` dependency to `>=1.0.0b1`
- Version bump to `1.0.0b1`
- Updated `AGENTS.md` with new runtime flow, migration notes, and app.yml ordering guidance

## Related
- Upstream DI fix: greatstrength/tiferet#827

---
[Conversation](https://app.warp.dev/conversation/7f34fba3-e332-4ec1-82d9-f6cd384e7f50)

Co-Authored-By: Oz <oz-agent@warp.dev>